### PR TITLE
Add some basic CI to the repository

### DIFF
--- a/.github/workflows/precommit.yaml
+++ b/.github/workflows/precommit.yaml
@@ -1,0 +1,30 @@
+name: Run pre-commit checks
+
+on:
+  pull_request:
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '^3.9'
+
+      - name: Configure caching
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pre-commit
+          key: ${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+
+      - name: Install requirements
+        run: |
+          pip install -r test-requirements.txt
+
+      - name: Run linters
+        run: |
+          pre-commit run

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+---
+repos:
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.1.9
+    hooks:
+      - id: remove-tabs
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+      - id: trailing-whitespace
+      - id: check-merge-conflict
+      - id: end-of-file-fixer
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-json
+      - id: check-symlinks
+      - id: detect-private-key
+
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.26.3
+    hooks:
+      - id: yamllint
+        files: \.(yaml|yml)$
+        types: [file, yaml]
+        entry: yamllint --strict

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,1 @@
+pre-commit


### PR DESCRIPTION
This runs [pre-commit][] with some basic linters for every pull request.

You can run these same checks in your local repostiory by installing
`pre-commit` locally:

- Run `pip install pre-commit` (or possibly `pip install --user
  pre-commit` if your `pip` is a bit older)

- From inside this repository, run `pre-commit install`

That's it! Now `pre-commit` will run whenever you make a new commit.

[pre-commit]: https://pre-commit.com/

Closes CCI-MOC/ops-issues#353