### PR TITLE
Ensure that "kustomize build" succeeds for all overlays

### DIFF
--- a/.github/workflows/precommit.yaml
+++ b/.github/workflows/precommit.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 jobs:
-  run-tests:
+  run-linters:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -19,7 +19,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.cache/pre-commit
-          key: ${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          key: precommit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
 
       - name: Install requirements
         run: |
@@ -28,3 +28,34 @@ jobs:
       - name: Run linters
         run: |
           pre-commit run
+
+  run-kustomize:
+    runs-on: ubuntu-latest
+    needs: run-linters
+    env:
+      KUSTOMIZE_VERSION: 4.3.0
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Configure caching
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/bin
+          key: kustomize-${{ runner.os }}-${{ env.KUSTOMIZE_VERSION }}
+
+      - name: Install kustomize
+        run: |
+          if ! [ -f "$HOME/.cache/bin/kustomize" ]; then
+            echo "Installing kustomize"
+            mkdir -p $HOME/.cache/bin
+            export PATH=$HOME/.cache/bin:$PATH
+            curl -Lsf -o kustomize.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz
+            tar -C $HOME/.cache/bin -xf kustomize.tar.gz
+          else
+            echo "Using kustomize from cache"
+          fi
+
+      - name: Run kustomize build
+        run: |
+          ./ci/run-kustomize-build.sh

--- a/ci/run-kustomize-build.sh
+++ b/ci/run-kustomize-build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+for overlay in cluster-scope/overlays/*; do
+    pushd $overlay > /dev/null
+    echo "Running kustomize in $overlay..."
+    kustomize build > /dev/null || exit 1
+    popd > /dev/null
+done


### PR DESCRIPTION
After successful linting, attempt to run `kustomize build` for all
overlays to catch missing files, typos, etc.
