### PR TITLE
Add nmstate deployment

### DIFF
--- a/cluster-scope/base/nmstate.io/nodenetworkstates/nmstate/kustomization.yaml
+++ b/cluster-scope/base/nmstate.io/nodenetworkstates/nmstate/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- nmstate.yaml

--- a/cluster-scope/base/nmstate.io/nodenetworkstates/nmstate/nmstate.yaml
+++ b/cluster-scope/base/nmstate.io/nodenetworkstates/nmstate/nmstate.yaml
@@ -1,0 +1,7 @@
+apiVersion: nmstate.io/v1beta1
+kind: NMState
+metadata:
+  name: nmstate
+spec:
+  nodeSelector:
+  ┆ "kubernetes.io/arch": "amd64"

--- a/cluster-scope/overlays/ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/ocp-prod/kustomization.yaml
@@ -2,4 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base/core/namespaces/openshift-nmstate
+  - ../../base/nmstate.io/nodenetworkstates/nmstate
   - nodenetworkconfigurationpolicies/ceph-client-network.yaml


### PR DESCRIPTION
The nmstate deployment lets us make use of resources such as
nodenetworkconfigurationpolicies.
