### PR TITLE
Fix a typo in nmstate resource

### DIFF
--- a/cluster-scope/base/nmstate.io/nodenetworkstates/nmstate/nmstate.yaml
+++ b/cluster-scope/base/nmstate.io/nodenetworkstates/nmstate/nmstate.yaml
@@ -4,4 +4,4 @@ metadata:
   name: nmstate
 spec:
   nodeSelector:
-  ┆ "kubernetes.io/arch": "amd64"
+    "kubernetes.io/arch": "amd64"


### PR DESCRIPTION
I managed to enter a bad character into the nmstate resource, which is
preventing it from applying cleanly.
