### PR TITLE
Import storageclasses into repository and make RBD the default

### DIFF
--- a/cluster-scope/base/storage.k8s.io/storageclasses/ocs-external-storagecluster-ceph-rbd/kustomization.yaml
+++ b/cluster-scope/base/storage.k8s.io/storageclasses/ocs-external-storagecluster-ceph-rbd/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- storageclass.yaml

--- a/cluster-scope/base/storage.k8s.io/storageclasses/ocs-external-storagecluster-ceph-rbd/storageclass.yaml
+++ b/cluster-scope/base/storage.k8s.io/storageclasses/ocs-external-storagecluster-ceph-rbd/storageclass.yaml
@@ -1,0 +1,23 @@
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+    annotations:
+        description: Provides RWO Filesystem volumes, and RWO and RWX Block volumes
+        storageclass.kubernetes.io/is-default-class: "true"
+    name: ocs-external-storagecluster-ceph-rbd
+parameters:
+    clusterID: openshift-storage
+    csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
+    csi.storage.k8s.io/controller-expand-secret-namespace: openshift-storage
+    csi.storage.k8s.io/fstype: ext4
+    csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
+    csi.storage.k8s.io/node-stage-secret-namespace: openshift-storage
+    csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
+    csi.storage.k8s.io/provisioner-secret-namespace: openshift-storage
+    imageFeatures: layering
+    imageFormat: "2"
+    pool: ocp-prod-rbd
+provisioner: openshift-storage.rbd.csi.ceph.com
+reclaimPolicy: Delete
+volumeBindingMode: Immediate

--- a/cluster-scope/base/storage.k8s.io/storageclasses/ocs-external-storagecluster-cephfs/kustomization.yaml
+++ b/cluster-scope/base/storage.k8s.io/storageclasses/ocs-external-storagecluster-cephfs/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- storageclass.yaml

--- a/cluster-scope/base/storage.k8s.io/storageclasses/ocs-external-storagecluster-cephfs/storageclass.yaml
+++ b/cluster-scope/base/storage.k8s.io/storageclasses/ocs-external-storagecluster-cephfs/storageclass.yaml
@@ -1,0 +1,21 @@
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+    annotations:
+        description: Provides RWO and RWX Filesystem volumes
+        storageclass.kubernetes.io/is-default-class: "false"
+    name: ocs-external-storagecluster-cephfs
+parameters:
+    clusterID: openshift-storage
+    csi.storage.k8s.io/controller-expand-secret-name: rook-csi-cephfs-provisioner
+    csi.storage.k8s.io/controller-expand-secret-namespace: openshift-storage
+    csi.storage.k8s.io/node-stage-secret-name: rook-csi-cephfs-node
+    csi.storage.k8s.io/node-stage-secret-namespace: openshift-storage
+    csi.storage.k8s.io/provisioner-secret-name: rook-csi-cephfs-provisioner
+    csi.storage.k8s.io/provisioner-secret-namespace: openshift-storage
+    fsName: cephfs
+    pool: cephfs
+provisioner: openshift-storage.cephfs.csi.ceph.com
+reclaimPolicy: Delete
+volumeBindingMode: Immediate

--- a/cluster-scope/base/storage.k8s.io/storageclasses/openshift-storage.noobaa.io/kustomization.yaml
+++ b/cluster-scope/base/storage.k8s.io/storageclasses/openshift-storage.noobaa.io/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- storageclass.yaml

--- a/cluster-scope/base/storage.k8s.io/storageclasses/openshift-storage.noobaa.io/storageclass.yaml
+++ b/cluster-scope/base/storage.k8s.io/storageclasses/openshift-storage.noobaa.io/storageclass.yaml
@@ -1,0 +1,12 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+    annotations:
+        description: Provides Object Bucket Claims (OBCs)
+        storageclass.kubernetes.io/is-default-class: "false"
+    name: openshift-storage.noobaa.io
+parameters:
+    bucketclass: noobaa-default-bucket-class
+provisioner: openshift-storage.noobaa.io/obc
+reclaimPolicy: Delete
+volumeBindingMode: Immediate

--- a/cluster-scope/overlays/ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/ocp-prod/kustomization.yaml
@@ -5,6 +5,9 @@ resources:
   - ../../base/nmstate.io/nodenetworkstates/nmstate
   - ../../base/operators.coreos.com/subscriptions/cert-manager
   - ../../base/rbac.authorization.k8s.io/clusterrolebindings/self-provisioners
+  - ../../base/storage.k8s.io/storageclasses/ocs-external-storagecluster-cephfs
+  - ../../base/storage.k8s.io/storageclasses/ocs-external-storagecluster-ceph-rbd
+  - ../../base/storage.k8s.io/storageclasses/openshift-storage.noobaa.io
   - ../../base/user.openshift.io/groups/cluster-admins/
 
   - nodenetworkconfigurationpolicies/ceph-client-network.yaml


### PR DESCRIPTION
Ensure we are managing storage class configuration via the repository,
and configure ocs-external-storagecluster-ceph-rbd as the default.

Closes cci-moc/ops-issues#346
