### PR TITLE
Add some resources that were purportedly added in previous commits

### DIFF
--- a/cluster-scope/overlays/ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/ocp-prod/kustomization.yaml
@@ -12,4 +12,8 @@ resources:
   - ../../base/storage.k8s.io/storageclasses/openshift-storage.noobaa.io
   - ../../base/user.openshift.io/groups/cluster-admins/
 
+  - certificates/default-ingress-certificate.yaml
   - nodenetworkconfigurationpolicies/ceph-client-network.yaml
+
+patchesStrategicMerge:
+  - groups/cluster-admins.yaml


### PR DESCRIPTION
There were some resources defined under base/ that never got included
in the ocp-prod overlay, despite the verbage in the associated commit
messages:

- The cluster-admins group
- The default ingress certificate

This commit includes both of them.
