### PR TITLE
Fix time specification in certificate

### DIFF
--- a/cluster-scope/overlays/ocp-prod/certificates/default-ingress-certificate.yaml
+++ b/cluster-scope/overlays/ocp-prod/certificates/default-ingress-certificate.yaml
@@ -7,7 +7,7 @@ spec:
   issuerRef:
     name: ingress-letsencrypt-production
   secretName: default-ingress-certificate
-  duration: 2160h
-  renewBefore: 360h
+  duration: 2160h0m0s
+  renewBefore: 360h0m0s
   dnsNames:
     - '*.apps.ocp-prod.massopen.cloud'


### PR DESCRIPTION
While the value e.g. `360h` is valid input for the `duration` or
`renewBefore` keys in the certificate, the canonical form includes
minutes and seconds as well (`360h0m0s`). The value is transformed
when the manifest is loaded on the cluster, so from ArgoCD's
perspective it never matches.

This commit updates the time specification to match the canonical
format.
