### PR TITLE
Configure ingress controller to use generated certificate

### DIFF
--- a/cluster-scope/overlays/ocp-prod/ingresscontrollers/default.yaml
+++ b/cluster-scope/overlays/ocp-prod/ingresscontrollers/default.yaml
@@ -1,0 +1,12 @@
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: default
+  namespace: openshift-ingress-operator
+spec:
+  httpErrorCodePages:
+    name: ""
+  replicas: 2
+  unsupportedConfigOverrides: null
+  defaultCertificate:
+    name: default-ingress-certificate

--- a/cluster-scope/overlays/ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/ocp-prod/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
 
   - certificates/default-ingress-certificate.yaml
   - nodenetworkconfigurationpolicies/ceph-client-network.yaml
+  - ingresscontrollers/default.yaml
 
 patchesStrategicMerge:
   - groups/cluster-admins.yaml


### PR DESCRIPTION
Configure the default ingress controller per [1] to use the
cert-manager generated certificate.

[1]: https://docs.openshift.com/container-platform/4.8/security/certificates/replacing-default-ingress-certificate.html
