### PR TITLE
Add external secrets for letsencrypt route53 access

### DIFF
--- a/cluster-scope/overlays/ocp-prod/externalsecrets/aws-route53-secret.yaml
+++ b/cluster-scope/overlays/ocp-prod/externalsecrets/aws-route53-secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: "kubernetes-client.io/v1"
+kind: ExternalSecret
+metadata:
+  name: aws-route53-secret
+  namespace: openshift-ingress
+spec:
+  backendType: secretsManager
+  data:
+    - key: cluster/ocp-prod/letsencrypt/aws_access_key_id
+      name: aws_access_key_id
+    - key: cluster/ocp-prod/letsencrypt/aws_secret_access_key
+      name: aws_secret_access_key

--- a/cluster-scope/overlays/ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/ocp-prod/kustomization.yaml
@@ -22,6 +22,7 @@ resources:
   - ../../base/rbac.authorization.k8s.io/clusterroles/moc-kubernetes-external-secrets
 
   - certificates/default-ingress-certificate.yaml
+  - externalsecrets/aws-route53-secret.yaml
   - nodenetworkconfigurationpolicies/ceph-client-network.yaml
   - ingresscontrollers/default.yaml
 


### PR DESCRIPTION
This adds an ExternalSecret that points to the AWS Route53 credentials
required by LetsEncrypt.
