### PR TITLE
Add missing clusterrolebinding cluster-admins-rb

### DIFF
--- a/cluster-scope/overlays/ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/ocp-prod/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ../../base/core/namespaces/openshift-nmstate
   - ../../base/nmstate.io/nodenetworkstates/nmstate
   - ../../base/operators.coreos.com/subscriptions/cert-manager
+  - ../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-rb
   - ../../base/rbac.authorization.k8s.io/clusterrolebindings/self-provisioners
   - ../../base/storage.k8s.io/storageclasses/ocs-external-storagecluster-cephfs
   - ../../base/storage.k8s.io/storageclasses/ocs-external-storagecluster-ceph-rbd


### PR DESCRIPTION
We were missing the clusterrolebinding for the cluster-admins group,
which means right now members of cluster-admins have no privileges.
This commit fixes that.

Also note that in addition to the clusterrolebinding named
`cluster-admins-rb` that is created by these manifests, there are also
clusterolebindings created by openshift named `cluster-admin` and
`cluster-admins`, so be sure you're looking at the right one :).
