### PR TITLE
Set the version of nfd operator in overlays instead of base

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/openshift-nfd/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/openshift-nfd/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: nfd
   namespace: openshift-nfd
 spec:
-  channel: "4.8"
+  channel: DEFINED_IN_OVERLAY
   installPlanApproval: Automatic
   name: nfd
   source: redhat-operators

--- a/cluster-scope/overlays/ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/ocp-prod/kustomization.yaml
@@ -33,3 +33,4 @@ resources:
 patchesStrategicMerge:
   - groups/cluster-admins.yaml
   - oauths/cluster_patch.yaml
+  - subscriptions/openshift-nfd_patch.yaml

--- a/cluster-scope/overlays/ocp-prod/subscriptions/openshift-nfd_patch.yaml
+++ b/cluster-scope/overlays/ocp-prod/subscriptions/openshift-nfd_patch.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: nfd
+  namespace: openshift-nfd
+spec:
+  # As of 2021-08-31, latest nfd version is 4.8
+  channel: "4.8"


### PR DESCRIPTION
I **think** this should be how we set the version, but I'd let Lars look at this once he's back. 
