### PR TITLE
This deploys and configures metallb on ocp-prod

### DIFF
--- a/cluster-scope/base/core/namespaces/metallb-system/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/metallb-system/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: metallb-system
+resources:
+- namespace.yaml

--- a/cluster-scope/base/core/namespaces/metallb-system/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/metallb-system/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: metallb-system
+  labels:
+    app: metallb

--- a/cluster-scope/base/policy/podsecuritypolicies/controller/kustomization.yaml
+++ b/cluster-scope/base/policy/podsecuritypolicies/controller/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- podsecuritypolicy.yaml

--- a/cluster-scope/base/policy/podsecuritypolicies/controller/podsecuritypolicy.yaml
+++ b/cluster-scope/base/policy/podsecuritypolicies/controller/podsecuritypolicy.yaml
@@ -1,0 +1,40 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  labels:
+    app: metallb
+  name: controller
+spec:
+  allowPrivilegeEscalation: false
+  allowedCapabilities: []
+  allowedHostPaths: []
+  defaultAddCapabilities: []
+  defaultAllowPrivilegeEscalation: false
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  hostIPC: false
+  hostNetwork: false
+  hostPID: false
+  privileged: false
+  readOnlyRootFilesystem: true
+  requiredDropCapabilities:
+  - ALL
+  runAsUser:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - secret
+  - emptyDir

--- a/cluster-scope/base/policy/podsecuritypolicies/speaker/kustomization.yaml
+++ b/cluster-scope/base/policy/podsecuritypolicies/speaker/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- podsecuritypolicy.yaml

--- a/cluster-scope/base/policy/podsecuritypolicies/speaker/podsecuritypolicy.yaml
+++ b/cluster-scope/base/policy/podsecuritypolicies/speaker/podsecuritypolicy.yaml
@@ -1,0 +1,37 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  labels:
+    app: metallb
+  name: speaker
+spec:
+  allowPrivilegeEscalation: false
+  allowedCapabilities:
+  - NET_ADMIN
+  - NET_RAW
+  - SYS_ADMIN
+  allowedHostPaths: []
+  defaultAddCapabilities: []
+  defaultAllowPrivilegeEscalation: false
+  fsGroup:
+    rule: RunAsAny
+  hostIPC: false
+  hostNetwork: true
+  hostPID: false
+  hostPorts:
+  - max: 7472
+    min: 7472
+  privileged: true
+  readOnlyRootFilesystem: true
+  requiredDropCapabilities:
+  - ALL
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - configMap
+  - secret
+  - emptyDir

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/metallb-allow-privileged/clusterrolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/metallb-allow-privileged/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: metallb-allow-privileged
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+  - kind: ServiceAccount
+    name: speaker
+    namespace: metallb-system

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/metallb-allow-privileged/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/metallb-allow-privileged/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- clusterrolebinding.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/metallb-system:controller/clusterrolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/metallb-system:controller/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: metallb
+  name: metallb-system:controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metallb-system:controller
+subjects:
+- kind: ServiceAccount
+  name: controller
+  namespace: metallb-system

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/metallb-system:controller/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/metallb-system:controller/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- clusterrolebinding.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/metallb-system:speaker/clusterrolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/metallb-system:speaker/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: metallb
+  name: metallb-system:speaker
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metallb-system:speaker
+subjects:
+- kind: ServiceAccount
+  name: speaker
+  namespace: metallb-system

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/metallb-system:speaker/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/metallb-system:speaker/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- clusterrolebinding.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/metallb-system:controller/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/metallb-system:controller/clusterrole.yaml
@@ -1,0 +1,37 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: metallb
+  name: metallb-system:controller
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - ''
+    resources:
+      - services/status
+    verbs:
+      - update
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - policy
+    resourceNames:
+      - controller
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/metallb-system:controller/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/metallb-system:controller/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- clusterrole.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/metallb-system:speaker/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/metallb-system:speaker/clusterrole.yaml
@@ -1,0 +1,32 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: metallb
+  name: metallb-system:speaker
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - services
+      - endpoints
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - policy
+    resourceNames:
+      - speaker
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/metallb-system:speaker/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/metallb-system:speaker/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- clusterrole.yaml

--- a/cluster-scope/overlays/ocp-prod/externalsecrets/metallb-memberlist-secret.yaml
+++ b/cluster-scope/overlays/ocp-prod/externalsecrets/metallb-memberlist-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: "kubernetes-client.io/v1"
+kind: ExternalSecret
+metadata:
+  name: memberlist
+  namespace: metallb-system
+spec:
+  backendType: secretsManager
+  data:
+    - key: cluster/ocp-prod/metallb/memberlist
+      name: secretkey

--- a/cluster-scope/overlays/ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/ocp-prod/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ../../base/cert-manager.io/issuers/ingress-letsencrypt-production
   - ../../base/cert-manager.io/issuers/ingress-letsencrypt-staging
   - ../../base/config.openshift.io/oauths/cluster
+  - ../../base/core/namespaces/metallb-system/
   - ../../base/core/namespaces/gpu-operator-resources/
   - ../../base/core/namespaces/openshift-nfd
   - ../../base/core/namespaces/openshift-nmstate
@@ -19,6 +20,13 @@ resources:
   - ../../base/storage.k8s.io/storageclasses/openshift-storage.noobaa.io
   - ../../base/user.openshift.io/groups/cluster-admins/
 
+  # metallb
+  - ../../base/rbac.authorization.k8s.io/clusterrolebindings/metallb-allow-privileged/
+  - ../../base/rbac.authorization.k8s.io/clusterrolebindings/metallb-system:controller/
+  - ../../base/rbac.authorization.k8s.io/clusterrolebindings/metallb-system:speaker/
+  - ../../base/rbac.authorization.k8s.io/clusterroles/metallb-system:controller/
+  - ../../base/rbac.authorization.k8s.io/clusterroles/metallb-system:speaker/
+
   # external secrets
   - ../../base/apiextensions.k8s.io/customresourcedefinitions/externalsecrets.kubernetes-client.io
   - ../../base/core/namespaces/external-secrets
@@ -28,6 +36,7 @@ resources:
 
   - certificates/default-ingress-certificate.yaml
   - externalsecrets/aws-route53-secret.yaml
+  - externalsecrets/metallb-memberlist-secret.yaml
   - nodefeaturediscoveries/node-feature-discovery.yaml
   - nodenetworkconfigurationpolicies/ceph-client-network.yaml
   - ingresscontrollers/default.yaml

--- a/metallb/base/daemonset.yaml
+++ b/metallb/base/daemonset.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: metallb
+    component: speaker
+  name: speaker
+  namespace: metallb-system
+spec:
+  selector:
+    matchLabels:
+      app: metallb
+      component: speaker
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: '7472'
+        prometheus.io/scrape: 'true'
+      labels:
+        app: metallb
+        component: speaker
+    spec:
+      containers:
+      - args:
+        - --port=7472
+        - --config=config
+        env:
+        - name: METALLB_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: METALLB_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: METALLB_ML_BIND_ADDR
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: METALLB_ML_LABELS
+          value: app=metallb,component=speaker
+        - name: METALLB_ML_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: METALLB_ML_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              key: secretkey
+              name: memberlist
+        image: metallb/speaker:v0.9.5
+        imagePullPolicy: Always
+        name: speaker
+        ports:
+        - containerPort: 7472
+          name: monitoring
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_ADMIN
+            - NET_RAW
+            - SYS_ADMIN
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: speaker
+      terminationGracePeriodSeconds: 2
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master

--- a/metallb/base/deployment.yaml
+++ b/metallb/base/deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: metallb
+    component: controller
+  name: controller
+  namespace: metallb-system
+spec:
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: metallb
+      component: controller
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: '7472'
+        prometheus.io/scrape: 'true'
+      labels:
+        app: metallb
+        component: controller
+    spec:
+      containers:
+      - args:
+        - --port=7472
+        - --config=config
+        image: metallb/controller:v0.9.5
+        imagePullPolicy: Always
+        name: controller
+        ports:
+        - containerPort: 7472
+          name: monitoring
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
+          readOnlyRootFilesystem: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: controller
+      terminationGracePeriodSeconds: 0

--- a/metallb/base/kustomization.yaml
+++ b/metallb/base/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: metallb-system
+
+resources:
+  - daemonset.yaml
+  - deployment.yaml
+  - rolebinding.yaml
+  - role.yaml
+  - serviceaccount.yaml

--- a/metallb/base/role.yaml
+++ b/metallb/base/role.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: metallb
+  name: config-watcher
+  namespace: metallb-system
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: metallb
+  name: pod-lister
+  namespace: metallb-system
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  verbs:
+  - list

--- a/metallb/base/rolebinding.yaml
+++ b/metallb/base/rolebinding.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: metallb
+  name: config-watcher
+  namespace: metallb-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: config-watcher
+subjects:
+- kind: ServiceAccount
+  name: controller
+- kind: ServiceAccount
+  name: speaker
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: metallb
+  name: pod-lister
+  namespace: metallb-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pod-lister
+subjects:
+- kind: ServiceAccount
+  name: speaker

--- a/metallb/base/serviceaccount.yaml
+++ b/metallb/base/serviceaccount.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: metallb
+  name: controller
+  namespace: metallb-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: metallb
+  name: speaker
+  namespace: metallb-system

--- a/metallb/overlays/ocp-prod/config.yaml
+++ b/metallb/overlays/ocp-prod/config.yaml
@@ -1,0 +1,5 @@
+address-pools:
+  - name: default
+    protocol: layer2
+    addresses:
+      - 128.52.61.128-128.52.61.255

--- a/metallb/overlays/ocp-prod/kustomization.yaml
+++ b/metallb/overlays/ocp-prod/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: metallb-system
+
+resources:
+  - ../../base
+
+configMapGenerator:
+  - name: config
+    files:
+      - config=config.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true


### PR DESCRIPTION
It's mostly based on https://github.com/operate-first/apps/pull/405
and https://gitlab.com/naved001/moc-cnv-sandbox/-/tree/moc-ocp/roles/ocp/metallb

The secret handling is different, because we are using ExternalSecrets controllers
in our case.