### PR TITLE
Move app-of-apps config into moc-apps repository

### DIFF
--- a/app-of-apps/envs/ocp-prod/cluster-scope/application.yaml
+++ b/app-of-apps/envs/ocp-prod/cluster-scope/application.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cluster-resources
+spec:
+  destination:
+    name: ocp-prod
+  ignoreDifferences:
+    - group: imageregistry.operator.openshift.io
+      jsonPointers:
+        - /spec/defaultRoute
+        - /spec/httpSecret
+        - /spec/proxy
+        - /spec/requests
+        - /spec/rolloutStrategy
+      kind: Config
+      name: cluster
+  project: mocops
+  source:
+    path: cluster-scope/overlays/ocp-prod
+    repoURL: https://github.com/CCI-MOC/moc-apps.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - Validate=false
+    - ApplyOutOfSyncOnly=true

--- a/app-of-apps/envs/ocp-prod/external-secrets/application.yaml
+++ b/app-of-apps/envs/ocp-prod/external-secrets/application.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: external-secrets
+spec:
+  destination:
+    name: ocp-prod
+  project: mocops
+  source:
+    path: external-secrets/overlays/ocp-prod
+    repoURL: https://github.com/CCI-MOC/moc-apps.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - Validate=false
+    - ApplyOutOfSyncOnly=true

--- a/app-of-apps/envs/ocp-prod/kustomization.yaml
+++ b/app-of-apps/envs/ocp-prod/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: open-cluster-management-agent
+resources:
+- cluster-scope/application.yaml
+- external-secrets/application.yaml


### PR DESCRIPTION
This consolidates our argocd config in a single repository, and avoids both (a) having to make commits to multiple repositories to enable a new top-level app, and (b) burdening operate-first members with review work that is more appropriate to the MOC ops team.

This will probably require coordinating the changes with the existing repository, so marking as a draft for now.