### PR TITLE
Configure moc-testing oauth realm

### DIFF
--- a/cluster-scope/overlays/ocp-prod/externalsecrets/sso-clientsecret-moc-testing.yaml
+++ b/cluster-scope/overlays/ocp-prod/externalsecrets/sso-clientsecret-moc-testing.yaml
@@ -1,10 +1,10 @@
 apiVersion: "kubernetes-client.io/v1"
 kind: ExternalSecret
 metadata:
-  name: moc-sso-client-secret
+  name: sso-clientsecret-moc-testing
   namespace: openshift-config
 spec:
   backendType: secretsManager
   data:
-    - key: cluster/ocp-prod/moc-sso/clientsecret
+    - key: cluster/ocp-prod/openshift-config/sso-clientsecret-moc-testing
       name: clientSecret

--- a/cluster-scope/overlays/ocp-prod/externalsecrets/sso-clientsecret-moc.yaml
+++ b/cluster-scope/overlays/ocp-prod/externalsecrets/sso-clientsecret-moc.yaml
@@ -1,0 +1,10 @@
+apiVersion: "kubernetes-client.io/v1"
+kind: ExternalSecret
+metadata:
+  name: sso-clientsecret-moc
+  namespace: openshift-config
+spec:
+  backendType: secretsManager
+  data:
+    - key: cluster/ocp-prod/openshift-config/sso-clientsecret-moc
+      name: clientSecret

--- a/cluster-scope/overlays/ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/ocp-prod/kustomization.yaml
@@ -28,7 +28,8 @@ resources:
 
   - certificates/default-ingress-certificate.yaml
   - externalsecrets/aws-route53-secret.yaml
-  - externalsecrets/moc-sso-client-secret.yaml
+  - externalsecrets/sso-clientsecret-moc.yaml
+  - externalsecrets/sso-clientsecret-moc-testing.yaml
   - nodefeaturediscoveries/node-feature-discovery.yaml
   - nodenetworkconfigurationpolicies/ceph-client-network.yaml
   - ingresscontrollers/default.yaml

--- a/cluster-scope/overlays/ocp-prod/oauths/cluster_patch.yaml
+++ b/cluster-scope/overlays/ocp-prod/oauths/cluster_patch.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   identityProviders:
     - mappingMethod: claim
-      name: moc-sso
+      name: moc
       openID:
         claims:
           email:
@@ -16,7 +16,23 @@ spec:
           - preferred_username
         clientID: moc-openshift-ocp-prod
         clientSecret:
-          name: moc-sso-client-secret
+          name: sso-clientsecret-moc
         extraScopes: []
         issuer: https://sso.massopen.cloud/auth/realms/moc
+      type: OpenID
+    - mappingMethod: claim
+      name: moc-testing
+      openID:
+        claims:
+          email:
+            - email
+          name:
+            - name
+          preferredUsername:
+            - preferred_username
+        clientID: moc-openshift-ocp-prod
+        clientSecret:
+          name: sso-clientsecret-moc-testing
+        extraScopes: []
+        issuer: https://sso.massopen.cloud/auth/realms/moc-testing
       type: OpenID


### PR DESCRIPTION
This gives us a sane place to creat test accounts for testing user mangement workflows, quotas, permissions, and other account-related activities.

This commit introduces a structure for oauth secret names, and renames the existing moc client secret to match. Specifically, rather than making up a secret name in AWS that doesn't match the secret name in OpenShift, I'm proposing:

```
/cluster/ocp-prod/<namespace>/<secretname>
```

Which gives us:

- `cluster/ocp-prod/openshift-config/clientsecret-moc`
- `cluster/ocp-prod/openshift-config/clientsecret-moc-testing`

For secrets named `clientsecret-moc` and `clientsecret-moc-testing` in
the `openshift-config` namespace.
