### PR TITLE
Add moc-projects service for creating projects from cci-moc/moc-openshift-projects repository

### DIFF
--- a/app-of-apps/envs/ocp-prod/cluster-scope/kustomization.yaml
+++ b/app-of-apps/envs/ocp-prod/cluster-scope/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- application.yaml

--- a/app-of-apps/envs/ocp-prod/external-secrets/kustomization.yaml
+++ b/app-of-apps/envs/ocp-prod/external-secrets/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- application.yaml

--- a/app-of-apps/envs/ocp-prod/kustomization.yaml
+++ b/app-of-apps/envs/ocp-prod/kustomization.yaml
@@ -4,5 +4,6 @@ namespace: argocd
 resources:
 - cluster-scope
 - external-secrets
+- moc-projects
 
 nameSuffix: -ocp-prod

--- a/app-of-apps/envs/ocp-prod/kustomization.yaml
+++ b/app-of-apps/envs/ocp-prod/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: argocd
 resources:
-- cluster-scope/application.yaml
-- external-secrets/application.yaml
+- cluster-scope
+- external-secrets
 
 nameSuffix: -ocp-prod

--- a/app-of-apps/envs/ocp-prod/moc-projects/application.yaml
+++ b/app-of-apps/envs/ocp-prod/moc-projects/application.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: moc-projects
+spec:
+  destination:
+    name: ocp-prod
+    namespace: open-cluster-management-agent
+  project: mocops
+  source:
+    path: moc-projects/overlays/ocp-prod
+    repoURL: https://github.com/CCI-MOC/moc-apps.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - Validate=false
+    - ApplyOutOfSyncOnly=true

--- a/app-of-apps/envs/ocp-prod/moc-projects/kustomization.yaml
+++ b/app-of-apps/envs/ocp-prod/moc-projects/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- application.yaml

--- a/cluster-scope/base/core/namespaces/moc-projects/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/moc-projects/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: moc-projects
+resources:
+- namespace.yaml

--- a/cluster-scope/base/core/namespaces/moc-projects/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/moc-projects/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: moc-projects
+spec: {}

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/project-maker-rb/clusterrolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/project-maker-rb/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+    name: project-maker-rb
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: project-maker
+subjects:
+    - kind: ServiceAccount
+      namespace: moc-projects
+      name: moc-project-maker

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/project-maker-rb/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/project-maker-rb/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - clusterrolebinding.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/project-maker/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/project-maker/clusterrole.yaml
@@ -1,0 +1,54 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    openshift.io/description: A role that can create new projects.
+  name: project-maker
+rules:
+  - apiGroups:
+      - ''
+      - user.openshift.io
+    resources:
+      - groups
+    verbs:
+      - get
+      - list
+      - create
+      - patch
+  - apiGroups:
+      - ''
+      - project.openshift.io
+    resources:
+      - projects
+      - namespaces
+    verbs:
+      - get
+      - list
+      - create
+      - patch
+  - apiGroups:
+      - ''
+    resources:
+      - limitranges
+      - resourcequotas
+    verbs:
+      - get
+      - list
+      - create
+      - patch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+    verbs:
+      - get
+      - list
+      - create
+      - patch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterroles
+    verbs:
+      - escalate
+      - bind

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/project-maker/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/project-maker/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - clusterrole.yaml

--- a/cluster-scope/overlays/ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/ocp-prod/kustomization.yaml
@@ -5,20 +5,23 @@ resources:
   - ../../base/cert-manager.io/issuers/ingress-letsencrypt-production
   - ../../base/cert-manager.io/issuers/ingress-letsencrypt-staging
   - ../../base/config.openshift.io/oauths/cluster
-  - ../../base/core/namespaces/gpu-operator-resources/
+  - ../../base/core/namespaces/gpu-operator-resources
+  - ../../base/core/namespaces/moc-projects
   - ../../base/core/namespaces/openshift-nfd
   - ../../base/core/namespaces/openshift-nmstate
   - ../../base/nmstate.io/nodenetworkstates/nmstate
   - ../../base/operators.coreos.com/operatorgroups/openshift-nfd
   - ../../base/operators.coreos.com/subscriptions/cert-manager
-  - ../../base/operators.coreos.com/subscriptions/gpu-operator-certified/
+  - ../../base/operators.coreos.com/subscriptions/gpu-operator-certified
   - ../../base/operators.coreos.com/subscriptions/openshift-nfd
   - ../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-rb
+  - ../../base/rbac.authorization.k8s.io/clusterrolebindings/project-maker-rb
   - ../../base/rbac.authorization.k8s.io/clusterrolebindings/self-provisioners
+  - ../../base/rbac.authorization.k8s.io/clusterroles/project-maker
   - ../../base/storage.k8s.io/storageclasses/ocs-external-storagecluster-cephfs
   - ../../base/storage.k8s.io/storageclasses/ocs-external-storagecluster-ceph-rbd
   - ../../base/storage.k8s.io/storageclasses/openshift-storage.noobaa.io
-  - ../../base/user.openshift.io/groups/cluster-admins/
+  - ../../base/user.openshift.io/groups/cluster-admins
 
   # external secrets
   - ../../base/apiextensions.k8s.io/customresourcedefinitions/externalsecrets.kubernetes-client.io

--- a/moc-projects/base/cronjob.yaml
+++ b/moc-projects/base/cronjob.yaml
@@ -1,0 +1,30 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: moc-projects
+spec:
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: moc-project-maker
+          containers:
+            - name: moc-projects
+              image: quay.io/larsks/moc-project-tool:latest
+              volumeMounts:
+                - name: moc-project-data
+                  mountPath: /data
+                - name: ansible-tmp
+                  mountPath: /.ansible
+              env:
+                - name: ANSIBLE_LOCAL_TMP
+                  value: /tmp
+          volumes:
+            - name: moc-project-data
+              persistentVolumeClaim:
+                claimName: moc-project-data
+            - name: ansible-tmp
+              emptyDir: {}
+          restartPolicy: Never

--- a/moc-projects/base/kustomization.yaml
+++ b/moc-projects/base/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: moc-projects
+commonLabels:
+  app: moc-projects
+
+resources:
+- persistentvolumeclaim.yaml
+- serviceaccount.yaml
+- cronjob.yaml

--- a/moc-projects/base/persistentvolumeclaim.yaml
+++ b/moc-projects/base/persistentvolumeclaim.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: moc-project-data
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi

--- a/moc-projects/base/serviceaccount.yaml
+++ b/moc-projects/base/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  name: moc-project-maker

--- a/moc-projects/overlays/ocp-prod/config.env
+++ b/moc-projects/overlays/ocp-prod/config.env
@@ -1,0 +1,4 @@
+PROJECT_DATA_DIR=/data/projects
+PROJECT_ACCEPT_HOSTKEY=true
+PROJECT_SSH_KEY=/secret/sshkey
+PROJECT_DATA_REPO=ssh://git@github.com/CCI-MOC/moc-openshift-projects.git

--- a/moc-projects/overlays/ocp-prod/cronjobs/moc-projects_patch.yaml
+++ b/moc-projects/overlays/ocp-prod/cronjobs/moc-projects_patch.yaml
@@ -7,10 +7,9 @@ spec:
     spec:
       template:
         spec:
-          serviceAccountName: moc-project-maker
           containers:
             - name: moc-projects
-              image: quay.io/larsks/moc-project-tool:d3dcc26
+              image: quay.io/larsks/moc-project-tool:ed34f0b
               volumeMounts:
                 - name: moc-project-key
                   mountPath: /secret

--- a/moc-projects/overlays/ocp-prod/cronjobs/moc-projects_patch.yaml
+++ b/moc-projects/overlays/ocp-prod/cronjobs/moc-projects_patch.yaml
@@ -1,0 +1,24 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: moc-projects
+spec:
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: moc-project-maker
+          containers:
+            - name: moc-projects
+              image: quay.io/larsks/moc-project-tool:d3dcc26
+              volumeMounts:
+                - name: moc-project-key
+                  mountPath: /secret
+              envFrom:
+                - configMapRef:
+                    name: moc-project-config
+          volumes:
+            - name: moc-project-key
+              secret:
+                secretName: moc-projects-private-key
+                defaultMode: 0400

--- a/moc-projects/overlays/ocp-prod/externalsecret.yaml
+++ b/moc-projects/overlays/ocp-prod/externalsecret.yaml
@@ -1,0 +1,9 @@
+apiVersion: "kubernetes-client.io/v1"
+kind: ExternalSecret
+metadata:
+  name: moc-projects-private-key
+spec:
+  backendType: secretsManager
+  data:
+    - key: cluster/ocp-prod/moc-projects/moc-projects-private-key
+      name: sshkey

--- a/moc-projects/overlays/ocp-prod/kustomization.yaml
+++ b/moc-projects/overlays/ocp-prod/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - externalsecret.yaml
+
+configMapGenerator:
+  - name: moc-project-config
+    envs:
+      - config.env
+
+patches:
+  - path: cronjobs/moc-projects_patch.yaml


### PR DESCRIPTION
This PR brings together several pieces:

- The [moc-openshift-projects](https://github.com/CCI-MOC/moc-openshift-projects) repository
- The [moc-project-tool](https://github.com/CCI-MOC/moc-project-tool) repository, via the [moc-project-tool](https://quay.io/repository/larsks/moc-project-tool?tab=tags) container image

With everything in place, commits to the `master` branch of the `moc-openshift-projects` will  cause the service to process files in the `projects/` directory and create new projects in OpenShift.

This PR is split into several commits; you can use the commit filter when reviewing the PR to limit the amount of changes you're looking at at any one time.

Closes https://github.com/CCI-MOC/ops-issues/issues/367