### PR TITLE
Fix namespace for external secret

### DIFF
--- a/moc-projects/overlays/ocp-prod/kustomization.yaml
+++ b/moc-projects/overlays/ocp-prod/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: moc-projects
 resources:
   - ../../base
   - externalsecret.yaml


### PR DESCRIPTION
The externalsecret resource in moc-projects was being created in the
wrong namespace.
