### PR TITLE
Update to moc-project-tool with admin/member support

### DIFF
--- a/moc-projects/overlays/ocp-prod/deployments/moc_projects_patch.yaml
+++ b/moc-projects/overlays/ocp-prod/deployments/moc_projects_patch.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
         - name: moc-projects
-          image: quay.io/larsks/moc-project-tool:d50d1c6
+          image: quay.io/larsks/moc-project-tool:96d8bd8
           envFrom:
             - configMapRef:
                 name: moc-project-config


### PR DESCRIPTION
This updates to a version of moc-project-tool that includes
https://github.com/CCI-MOC/moc-project-tool/pull/2.
