### PR TITLE
Diff kustomize build output in pr workflow

### DIFF
--- a/.github/workflows/precommit.yaml
+++ b/.github/workflows/precommit.yaml
@@ -34,6 +34,7 @@ jobs:
     needs: run-linters
     env:
       KUSTOMIZE_VERSION: 4.3.0
+      TERM: xterm-256color
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -59,3 +60,8 @@ jobs:
       - name: Run kustomize build
         run: |
           ./ci/run-kustomize-build.sh
+
+      - name: Diff with target
+        run: |
+          git fetch origin $GITHUB_BASE_REF:$GITHUB_BASE_REF
+          ./ci/diff-all-with-previous.sh -r $GITHUB_BASE_REF

--- a/ci/diff-all-with-previous.sh
+++ b/ci/diff-all-with-previous.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+find_overlays() {
+    find * -type f -regex '.*/overlays/.*/kustomization.yaml' -printf '%h\n'
+}
+
+OPT_BASE_REF='HEAD^'
+
+while getopts fr: ch; do
+    case "$ch" in
+        (r)     OPT_BASE_REF=$OPTARG
+                ;;
+
+        (f)     OPT_FORCE=1
+                ;;
+
+        (\?)    echo "ERROR: unknown option: $1" >&2
+                exit 2
+                ;;
+    esac
+done
+shift $(( OPTIND - 1 ))
+
+cat <<EOF
+##
+## Diff 'kustomize build' between $OPT_BASE_REF and HEAD
+##
+
+EOF
+
+for overlay in $(find_overlays); do
+    echo "=== $overlay ==="
+    ./ci/diff-with-previous.sh -r ${OPT_BASE_REF} ${OPT_FORCE:+-f} $overlay
+done

--- a/ci/diff-with-previous.sh
+++ b/ci/diff-with-previous.sh
@@ -2,14 +2,17 @@
 
 OPT_REVISION='HEAD^'
 
-while getopts r: ch; do
-    case "$1" in
-        (-r)    OPT_REVISION=$OPTARG
+while getopts fr: ch; do
+    case "$ch" in
+        (r)     OPT_REVISION=$OPTARG
                 ;;
 
+        (f)     OPT_FORCE=1
+        ;;
+
         (\?)    echo "ERROR: unknown optoin: $1" >&2
-               exit 2
-               ;;
+                exit 2
+                ;;
     esac
 done
 shift $(( OPTIND - 1 ))
@@ -27,7 +30,7 @@ if ! [[ -d "$overlay" ]]; then
     exit 1
 fi
 
-if ! git diff-index --quiet HEAD; then
+if [[ -z $OPT_FORCE ]] && ! git diff-index --quiet HEAD; then
     echo "ERROR: please commit your changes first." >&2
     exit 1
 fi

--- a/ci/diff-with-previous.sh
+++ b/ci/diff-with-previous.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-OPT_REVISION='HEAD^'
+OPT_BASE_REF='HEAD^'
 
 while getopts fr: ch; do
     case "$ch" in
-        (r)     OPT_REVISION=$OPTARG
+        (r)     OPT_BASE_REF=$OPTARG
                 ;;
 
         (f)     OPT_FORCE=1
@@ -41,9 +41,9 @@ workdir=$(mktemp -d tmp.kustomizeXXXXXX)
 trap "rm -rf $workdir" EXIT
 
 mkdir -p $workdir/prev $workdir/head
-git archive "${OPT_REVISION}" | tar -C $workdir/prev -xf -
+git archive "${OPT_BASE_REF}" | tar -C $workdir/prev -xf -
 git archive HEAD | tar -C $workdir/head -xf -
 
 diff -u \
-    <(cd $workdir/prev/${overlay} && kustomize build) \
-    <(cd $workdir/head/${overlay} && kustomize build)
+    <(kustomize build $workdir/prev/${overlay}) \
+    <(kustomize build $workdir/head/${overlay})


### PR DESCRIPTION
This PR discovers overlays in the repository for each overlay diffs the output of `kustomize build` in the HEAD of the repository with the output from the pull request. This is particularly useful to demonstrate that a pull request that claims to make no functional changes to the repository configuration behaves as expected.