### PR TITLE
Update gpu-cluster-policy so argocd is in sync

### DIFF
--- a/cluster-scope/base/nvidia.com/clusterpolicy/gpu-cluster-policy/gpu-cluster-policy.yaml
+++ b/cluster-scope/base/nvidia.com/clusterpolicy/gpu-cluster-policy/gpu-cluster-policy.yaml
@@ -60,7 +60,6 @@ spec:
     securityContext: {}
     tolerations: []
     version: 'sha256:bfc39d23568458dfd50c0c5323b6d42bdcd038c420fb2a2becd513a3ed3be27f'
-    sleepInterval: 60s
   operator:
     defaultRuntime: crio
     validator:
@@ -68,7 +67,6 @@ spec:
       imagePullSecrets: []
       repository: nvcr.io/nvidia/k8s
       version: 'sha256:2a30fe7e23067bc2c3f8f62a6867702a016af2b80b9f6ce861f3fea4dfd85bc2'
-    deployGFD: true
   toolkit:
     affinity: {}
     image: container-toolkit


### PR DESCRIPTION
The live manifest does not have the parameters that this PR removes.

Here's a screenshot of argocd.

![image](https://user-images.githubusercontent.com/20113064/136216631-1cd401c4-e225-4ff7-b31b-ea98af6b2853.png)
