### PR TITLE
Configure slack notifications for critical alerts

### DIFF
--- a/cluster-scope/overlays/ocp-prod/externalsecrets/alertmanager-main.yaml
+++ b/cluster-scope/overlays/ocp-prod/externalsecrets/alertmanager-main.yaml
@@ -1,0 +1,10 @@
+apiVersion: "kubernetes-client.io/v1"
+kind: ExternalSecret
+metadata:
+  name: alertmanager-main
+  namespace: openshift-monitoring
+spec:
+  backendType: secretsManager
+  data:
+    - key: cluster/ocp-prod/openshift-monitoring/alertmanager-main
+      name: alertmanager.yaml

--- a/cluster-scope/overlays/ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/ocp-prod/kustomization.yaml
@@ -39,6 +39,7 @@ resources:
   - externalsecrets/aws-route53-secret.yaml
   - externalsecrets/sso-clientsecret-moc-testing.yaml
   - externalsecrets/sso-clientsecret-moc.yaml
+  - externalsecrets/alertmanager-main.yaml
   - ingresscontrollers/default.yaml
   - machineconfigs/99-master-ssh.yaml
   - machineconfigs/99-worker-ssh.yaml


### PR DESCRIPTION
This will send critical alerts to the #mocops channel.

Closes cci-moc/ops-issues#352
