### PR TITLE
Add OCS configuration

### DIFF
--- a/cluster-scope/base/ocs.openshift.io/storageclusters/ocs-external-storagecluster/kustomization.yaml
+++ b/cluster-scope/base/ocs.openshift.io/storageclusters/ocs-external-storagecluster/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - storagecluster.yaml

--- a/cluster-scope/base/ocs.openshift.io/storageclusters/ocs-external-storagecluster/storagecluster.yaml
+++ b/cluster-scope/base/ocs.openshift.io/storageclusters/ocs-external-storagecluster/storagecluster.yaml
@@ -1,0 +1,12 @@
+apiVersion: ocs.openshift.io/v1
+kind: StorageCluster
+metadata:
+    annotations:
+        uninstall.ocs.openshift.io/cleanup-policy: delete
+        uninstall.ocs.openshift.io/mode: graceful
+    name: ocs-external-storagecluster
+    namespace: openshift-storage
+spec:
+    externalStorage:
+        enable: true
+    version: 4.8.0

--- a/cluster-scope/bundles/ocs/kustomization.yaml
+++ b/cluster-scope/bundles/ocs/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - ../../base/storage.k8s.io/storageclasses/ocs-external-storagecluster-cephfs
   - ../../base/storage.k8s.io/storageclasses/ocs-external-storagecluster-ceph-rbd
   - ../../base/storage.k8s.io/storageclasses/openshift-storage.noobaa.io
+  - ../../base/ocs.openshift.io/storageclusters/ocs-external-storagecluster

--- a/cluster-scope/overlays/ocp-prod/externalsecrets/rook-ceph-external-cluster-details.yaml
+++ b/cluster-scope/overlays/ocp-prod/externalsecrets/rook-ceph-external-cluster-details.yaml
@@ -1,0 +1,10 @@
+apiVersion: "kubernetes-client.io/v1"
+kind: ExternalSecret
+metadata:
+  name: rook-ceph-external-cluster-details
+  namespace: openshift-storage
+spec:
+  backendType: secretsManager
+  data:
+    - key: cluster/ocp-prod/openshift-storage/rook-ceph-external-cluster-details
+      name: external_cluster_details

--- a/cluster-scope/overlays/ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/ocp-prod/kustomization.yaml
@@ -28,6 +28,7 @@ resources:
   - certificates/default-ingress-certificate.yaml
   - clusterversions/version.yaml
   - externalsecrets/aws-route53-secret.yaml
+  - externalsecrets/rook-ceph-external-cluster-details.yaml
   - externalsecrets/sso-clientsecret-moc-testing.yaml
   - externalsecrets/sso-clientsecret-moc.yaml
   - externalsecrets/alertmanager-main.yaml


### PR DESCRIPTION
Add the storagecluster and rook-ceph-external-cluster-details secret
necessary to configure OCS (these already exist in openshift; this
commit just makes them part of our repository as well).
