### PR TITLE
Configure persistent storage for Prometheus

### DIFF
--- a/cluster-scope/overlays/ocp-prod/configmaps/cluster-monitoring-config.yaml
+++ b/cluster-scope/overlays/ocp-prod/configmaps/cluster-monitoring-config.yaml
@@ -1,0 +1,14 @@
+prometheusK8s:
+  volumeClaimTemplate:
+    spec:
+      storageClassName: ocs-external-storagecluster-ceph-rbd
+      resources:
+        requests:
+          storage: 50Gi
+alertmanagerMain:
+  volumeClaimTemplate:
+    spec:
+      storageClassName: ocs-external-storagecluster-ceph-rbd
+      resources:
+        requests:
+          storage: 20Gi

--- a/cluster-scope/overlays/ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/ocp-prod/kustomization.yaml
@@ -37,6 +37,15 @@ resources:
   - nodefeaturediscoveries/node-feature-discovery.yaml
   - nodenetworkconfigurationpolicies/ceph-client-network.yaml
 
+generatorOptions:
+  disableNameSuffixHash: true
+
+configMapGenerator:
+  - name: cluster-monitoring-config
+    namespace: openshift-monitoring
+    files:
+      - config.yaml=configmaps/cluster-monitoring-config.yaml
+
 patchesStrategicMerge:
   - groups/cluster-admins.yaml
   - oauths/cluster_patch.yaml


### PR DESCRIPTION
By default, prometheus uses emptyDir storage for metrics, which means
it is bound to the node on which prometheus is running and will be
lost if the prometheus pods are restarted, recreated, etc.

This commits configure persistent storage for Prometheus following [1].

[1]: https://docs.openshift.com/container-platform/4.8/monitoring/configuring-the-monitoring-stack.html#configuring-persistent-storage
