### PR TITLE
Bundle vertical-pod-autoscaler resources

### DIFF
--- a/cluster-scope/bundles/vertical-pod-autoscaler/kustomization.yaml
+++ b/cluster-scope/bundles/vertical-pod-autoscaler/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base/core/namespaces/openshift-vertical-pod-autoscaler
+  - ../../base/operators.coreos.com/operatorgroups/openshift-vertical-pod-autoscaler
+  - ../../base/operators.coreos.com/subscriptions/vertical-pod-autoscaler

--- a/cluster-scope/overlays/ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/ocp-prod/kustomization.yaml
@@ -9,16 +9,13 @@ resources:
   - ../../base/core/namespaces/gpu-operator-resources
   - ../../base/core/namespaces/moc-projects
   - ../../base/core/namespaces/openshift-nfd
-  - ../../base/core/namespaces/openshift-vertical-pod-autoscaler
   - ../../base/core/persistentvolumeclaims/image-registry-storage
   - ../../base/imageregistry.operator.openshift.io/configs/cluster
   - ../../base/nvidia.com/clusterpolicy/gpu-cluster-policy
   - ../../base/operators.coreos.com/operatorgroups/openshift-nfd
-  - ../../base/operators.coreos.com/operatorgroups/openshift-vertical-pod-autoscaler
   - ../../base/operators.coreos.com/subscriptions/cert-manager
   - ../../base/operators.coreos.com/subscriptions/gpu-operator-certified
   - ../../base/operators.coreos.com/subscriptions/openshift-nfd
-  - ../../base/operators.coreos.com/subscriptions/vertical-pod-autoscaler
   - ../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-rb
   - ../../base/rbac.authorization.k8s.io/clusterrolebindings/project-maker-rb
   - ../../base/rbac.authorization.k8s.io/clusterrolebindings/self-provisioners
@@ -28,6 +25,7 @@ resources:
   - ../../bundles/external-secrets
   - ../../bundles/nmstate
   - ../../bundles/ocs
+  - ../../bundles/vertical-pod-autoscaler
 
   - certificates/default-ingress-certificate.yaml
   - clusterversions/version.yaml


### PR DESCRIPTION
This relocates some resource links from the ocp-prod overlay to
bundles/vertical-pod-autoscaler.
