### PR TITLE
Create letsencrypt clusterissuer

### DIFF
--- a/cluster-scope/base/cert-manager.io/clusterissuers/kustomization.yaml
+++ b/cluster-scope/base/cert-manager.io/clusterissuers/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- letsencrypt-production-http.yaml

--- a/cluster-scope/base/cert-manager.io/clusterissuers/letsencrypt-production-http.yaml
+++ b/cluster-scope/base/cert-manager.io/clusterissuers/letsencrypt-production-http.yaml
@@ -1,0 +1,23 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-production-dns01
+spec:
+  acme:
+    email: ops@list.massopen.cloud
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: letsencrypt-production-key
+    solvers:
+      - selector:
+          dnsZones:
+            - "ocp-prod.massopen.cloud"
+        dns01:
+          cnameStrategy: Follow
+          route53:
+            region: us-east-1
+            accessKeyID: AKIAYLUGMT7YARAARH6F
+            hostedZoneID: Z04486682XFINHTESP6B9
+            secretAccessKeySecretRef:
+              name: aws-route53-secret
+              key: aws_secret_access_key

--- a/cluster-scope/base/kubernetes-client.io/externalsecrets/aws-route53-secret/externalsecret.yaml
+++ b/cluster-scope/base/kubernetes-client.io/externalsecrets/aws-route53-secret/externalsecret.yaml
@@ -1,0 +1,14 @@
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+    labels:
+        app.kubernetes.io/instance: cluster-resources-ocp-prod
+    name: aws-route53-secret
+    namespace: openshift-ingress
+spec:
+    backendType: secretsManager
+    data:
+        - key: cluster/ocp-prod/letsencrypt/aws_access_key_id
+          name: aws_access_key_id
+        - key: cluster/ocp-prod/letsencrypt/aws_secret_access_key
+          name: aws_secret_access_key

--- a/cluster-scope/base/kubernetes-client.io/externalsecrets/aws-route53-secret/kustomization.yaml
+++ b/cluster-scope/base/kubernetes-client.io/externalsecrets/aws-route53-secret/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-operators
+resources:
+- externalsecret.yaml

--- a/cluster-scope/bundles/cert-manager/kustomization.yaml
+++ b/cluster-scope/bundles/cert-manager/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base/cert-manager.io/clusterissuers
+  - ../../base/cert-manager.io/issuers/ingress-letsencrypt-production
+  - ../../base/cert-manager.io/issuers/ingress-letsencrypt-staging
+  - ../../base/kubernetes-client.io/externalsecrets/aws-route53-secret
+  - ../../base/operators.coreos.com/subscriptions/cert-manager

--- a/cluster-scope/overlays/ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/ocp-prod/kustomization.yaml
@@ -2,8 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   # please keep these items sorted
-  - ../../base/cert-manager.io/issuers/ingress-letsencrypt-production
-  - ../../base/cert-manager.io/issuers/ingress-letsencrypt-staging
   - ../../base/config.openshift.io/oauths/cluster
   - ../../base/core/namespaces/cs6620-fall21-deployverticalpod
   - ../../base/core/namespaces/gpu-operator-resources
@@ -14,7 +12,6 @@ resources:
   - ../../base/imageregistry.operator.openshift.io/configs/cluster
   - ../../base/nvidia.com/clusterpolicy/gpu-cluster-policy
   - ../../base/operators.coreos.com/operatorgroups/openshift-nfd
-  - ../../base/operators.coreos.com/subscriptions/cert-manager
   - ../../base/operators.coreos.com/subscriptions/crunchy-postgres
   - ../../base/operators.coreos.com/subscriptions/gpu-operator-certified
   - ../../base/operators.coreos.com/subscriptions/openshift-nfd
@@ -24,6 +21,7 @@ resources:
   - ../../base/rbac.authorization.k8s.io/clusterroles/project-maker
   - ../../base/user.openshift.io/groups/cluster-admins
 
+  - ../../bundles/cert-manager
   - ../../bundles/external-secrets
   - ../../bundles/nmstate
   - ../../bundles/ocs


### PR DESCRIPTION
We have existing cert-manager issuers in the openshift-ingress
namespace, but now that we are looking at creating certificates in
other namespaces it makes sense to replace this with a ClusterIssuer
resource.

This commit creates the ClusterIssuer; a subsequent pr will remove the
namespaced-issuers and update the appropriate certificate requests.

Part of cci-moc/ops-issues#443
