### PR TITLE
[netbox] Work around kustomize version skew

### DIFF
--- a/netbox/base/deployments/netbox.yaml
+++ b/netbox/base/deployments/netbox.yaml
@@ -19,7 +19,7 @@ spec:
       containers:
         - name: netbox
           image: netbox
-          env: &env
+          env:
             - name: REDIS_HOST
               value: "redis"
             - name: REDIS_CACHE_HOST
@@ -46,13 +46,29 @@ spec:
             periodSeconds: 10
         - name: netbox-worker
           image: netbox
+          env:
+            - name: REDIS_HOST
+              value: "redis"
+            - name: REDIS_CACHE_HOST
+              value: "redis-cache"
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_CACHE_PORT
+              value: "6379"
           command:
             - /opt/netbox/venv/bin/python3
             - /opt/netbox/netbox/manage.py
             - rqworker
-          env: *env
         - name: netbox-housekeeping
           image: netbox
+          env:
+            - name: REDIS_HOST
+              value: "redis"
+            - name: REDIS_CACHE_HOST
+              value: "redis-cache"
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_CACHE_PORT
+              value: "6379"
           command:
             - /opt/netbox/housekeeping.sh
-          env: *env

--- a/netbox/overlays/ocp-prod/deployments/netbox_config_patch.yaml
+++ b/netbox/overlays/ocp-prod/deployments/netbox_config_patch.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
         - name: netbox
-          env: &env
+          env:
             - name: DB_HOST
               valueFrom:
                 secretKeyRef:
@@ -28,21 +28,71 @@ spec:
                 secretKeyRef:
                   name: netbox-pguser-netbox
                   key: dbname
-          envFrom: &envFrom
+          envFrom:
             - secretRef:
                 name: netbox-secret
-          volumeMounts: &volumeMounts
+          volumeMounts:
             - name: netbox-config
               mountPath: /etc/netbox/config/extra.py
               subPath: extra.py
         - name: netbox-worker
-          env: *env
-          envFrom: *envFrom
-          volumeMounts: *volumeMounts
+          env:
+            - name: DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: netbox-pguser-netbox
+                  key: host
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: netbox-pguser-netbox
+                  key: user
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: netbox-pguser-netbox
+                  key: password
+            - name: DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: netbox-pguser-netbox
+                  key: dbname
+          envFrom:
+            - secretRef:
+                name: netbox-secret
+          volumeMounts:
+            - name: netbox-config
+              mountPath: /etc/netbox/config/extra.py
+              subPath: extra.py
         - name: netbox-housekeeping
-          env: *env
-          envFrom: *envFrom
-          volumeMounts: *volumeMounts
+          env:
+            - name: DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: netbox-pguser-netbox
+                  key: host
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: netbox-pguser-netbox
+                  key: user
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: netbox-pguser-netbox
+                  key: password
+            - name: DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: netbox-pguser-netbox
+                  key: dbname
+          envFrom:
+            - secretRef:
+                name: netbox-secret
+          volumeMounts:
+            - name: netbox-config
+              mountPath: /etc/netbox/config/extra.py
+              subPath: extra.py
       volumes:
         - name: netbox-config
           configMap:


### PR DESCRIPTION
Kustomize 4.4.0 [1], which I am running locally, has much improved support
for YAML anchors and aliases. Our argocd environment is running 4.3.0,
which was failing to render the manifests in this application
correctly.

I've rewritten the manifests to work correctly with both versions, but
once operate-first/SRE#421 is resolved we can revert these changes.

[1]: https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv4.4.0

