### PR TITLE
Install operator subscriptions before other resources

### DIFF
--- a/cluster-scope/overlays/ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/ocp-prod/kustomization.yaml
@@ -51,6 +51,11 @@ configMapGenerator:
     files:
       - config.yaml=configmaps/cluster-monitoring-config.yaml
 
-patchesStrategicMerge:
-  - groups/cluster-admins.yaml
-  - oauths/cluster_patch.yaml
+patches:
+  - path: groups/cluster-admins.yaml
+  - path: oauths/cluster_patch.yaml
+
+  - target:
+      kind: Subscription
+      group: operators.coreos.com
+    path: subscriptions/subscription-wave_patch.yaml

--- a/cluster-scope/overlays/ocp-prod/subscriptions/subscription-wave_patch.yaml
+++ b/cluster-scope/overlays/ocp-prod/subscriptions/subscription-wave_patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: not-important
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"

--- a/cluster-scope/overlays/ocp-staging/kustomization.yaml
+++ b/cluster-scope/overlays/ocp-staging/kustomization.yaml
@@ -1,7 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  # please keep these items sorted
   - ../../base/config.openshift.io/oauths/cluster
   - ../../bundles/cert-manager
   - ../../bundles/external-secrets
@@ -11,11 +10,15 @@ resources:
   - certificates/default-ingress-certificate.yaml
   - externalsecrets/sso-clientsecret-moc.yaml
 
-patchesStrategicMerge:
-  - oauths/cluster_patch.yaml
-
 patches:
-  - path: clusterissuers/letsencrypt-production-dns01_patch.yaml
-    target:
+  - path: oauths/cluster_patch.yaml
+
+  - target:
       kind: ClusterIssuer
       name: letsencrypt-production-dns01
+    path: clusterissuers/letsencrypt-production-dns01_patch.yaml
+
+  - target:
+      kind: Subscription
+      group: operators.coreos.com
+    path: subscriptions/subscription-wave_patch.yaml

--- a/cluster-scope/overlays/ocp-staging/subscriptions/subscription-wave_patch.yaml
+++ b/cluster-scope/overlays/ocp-staging/subscriptions/subscription-wave_patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: not-important
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"


### PR DESCRIPTION
Instruct argocd to install operator subscriptions before other
resources by instructing argocd to install them at an earlier sync
wave [1] by setting the `argocd.argoproj.io/sync-wave` annotation to
`"-1"`.

[1]: https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/

