### PR TITLE
Correct invalid ClusterIssuer resource in ocp-staging overlay

### DIFF
--- a/cluster-scope/base/cert-manager.io/clusterissuers/letsencrypt-production-http.yaml
+++ b/cluster-scope/base/cert-manager.io/clusterissuers/letsencrypt-production-http.yaml
@@ -9,10 +9,7 @@ spec:
     privateKeySecretRef:
       name: letsencrypt-production-key
     solvers:
-      - selector:
-          dnsZones:
-            - "ocp-prod.massopen.cloud"
-        dns01:
+      - dns01:
           cnameStrategy: Follow
           route53:
             region: us-east-1

--- a/cluster-scope/overlays/ocp-prod/clusterissuers/letsencrypt-production-dns01_patch.yaml
+++ b/cluster-scope/overlays/ocp-prod/clusterissuers/letsencrypt-production-dns01_patch.yaml
@@ -2,4 +2,4 @@
   path: /spec/acme/solvers/0/selector
   value:
     dnsZones:
-      - ocp-staging.massopen.cloud
+      - ocp-prod.massopen.cloud

--- a/cluster-scope/overlays/ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/ocp-prod/kustomization.yaml
@@ -56,6 +56,11 @@ patches:
   - path: oauths/cluster_patch.yaml
 
   - target:
+      kind: ClusterIssuer
+      name: letsencrypt-production-dns01
+    path: clusterissuers/letsencrypt-production-dns01_patch.yaml
+
+  - target:
       kind: Subscription
       group: operators.coreos.com
     path: subscriptions/subscription-wave_patch.yaml


### PR DESCRIPTION
cluster-scope/overlays/ocp-staging had a patch that erroneously
replaced a list with a string value in the ClusterIssuer manifest.
This corrects the patch (and makes the ocp-prod and ocp-staging
overlays consistent in how they handle the configuration of the
resource).

