### PR TITLE
Read schemas directly from github rather than requiring local checkout

### DIFF
--- a/.github/workflows/precommit.yaml
+++ b/.github/workflows/precommit.yaml
@@ -43,13 +43,9 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Check out schemas
-        run:
-          git clone --depth 1 https://github.com/cci-moc/openshift-schemas
-
       - name: Run validations
         run: |
-          ./ci/validate-manifests.sh -i -v -s openshift-schemas/schemas
+          ./ci/validate-manifests.sh
 
       - name: Diff with target
         run: |

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ checkout of the `moc-apps` repository:
 ```
 #!/bin/sh
 
-./ci/validate-manifests.sh -s ../openshift-schemas/schemas
+./ci/validate-manifests.sh
 ```
 
 Ensure the file is executable:

--- a/ci/validate-manifests.sh
+++ b/ci/validate-manifests.sh
@@ -3,6 +3,7 @@
 : ${KUSTOMIZE:=kustomize}
 : ${KUBEVAL:=kubeval}
 : ${CONFTEST:=conftest}
+: ${SCHEMA_LOCATION:=https://raw.githubusercontent.com/CCI-MOC/openshift-schemas/master/schemas/}
 
 find_overlays() {
     find * -type f -regex '.*/overlays/.*/kustomization.yaml' -printf '%h\n'
@@ -21,9 +22,6 @@ fail() {
 
 while getopts vis: ch; do
     case $ch in
-        (v) VALIDATE=1
-            ;;
-
         (i) IGNORE_MISSING_SCHEMAS=1
             ;;
 
@@ -48,7 +46,7 @@ for overlay in $(find_overlays); do
 
     if $KUBEVAL --strict \
         ${IGNORE_MISSING_SCHEMAS:+--ignore-missing-schemas} \
-        ${SCHEMA_LOCATION:+--additional-schema-locations file://$SCHEMA_LOCATION} \
+        ${SCHEMA_LOCATION:+--additional-schema-locations $SCHEMA_LOCATION} \
             $tmpdir/manifests.yaml > $tmpdir/stdout 2> $tmpdir/stderr; then
         okay schema
     else


### PR DESCRIPTION
Previously, the validation script required a local checkout of the
openshift-schemas repository [1]. It turns out we can point kubeval
directly at GitHub, which simplifies both the ci workflow as well as
the necessary configuration required to run the validation locally.

[1]: https://github.com/CCI-MOC/openshift-schemas/
