### PR TITLE
Remove startCSV from cert-manager subscription

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/cert-manager/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/cert-manager/subscription.yaml
@@ -11,4 +11,3 @@ spec:
     name: cert-manager
     source: community-operators
     sourceNamespace: openshift-marketplace
-    startingCSV: cert-manager.v1.5.3


### PR DESCRIPTION
Setting startingCSV in the subscription seems to lead to problems, as
we've seen recently with both external-secrets and ocs. This commit
removes it from cert-manager, which was the last remaining
subscription that was setting this attribute.
