### PR TITLE
Install namespaces in sync wave -1

### DIFF
--- a/cluster-scope/overlays/ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/ocp-prod/kustomization.yaml
@@ -53,4 +53,8 @@ patches:
   - target:
       kind: Subscription
       group: operators.coreos.com
-    path: subscriptions/subscription-wave_patch.yaml
+    path: misc/sync-wave_patch.yaml
+
+  - target:
+      kind: Namespace
+    path: misc/sync-wave_patch.yaml

--- a/cluster-scope/overlays/ocp-prod/misc/sync-wave_patch.yaml
+++ b/cluster-scope/overlays/ocp-prod/misc/sync-wave_patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: does-not-matter
+kind: does-not-matter
+metadata:
+  name: does-not-matter
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"

--- a/cluster-scope/overlays/ocp-prod/subscriptions/subscription-wave_patch.yaml
+++ b/cluster-scope/overlays/ocp-prod/subscriptions/subscription-wave_patch.yaml
@@ -1,6 +1,0 @@
-apiVersion: operators.coreos.com/v1alpha1
-kind: Subscription
-metadata:
-  name: not-important
-  annotations:
-    argocd.argoproj.io/sync-wave: "-1"

--- a/cluster-scope/overlays/ocp-staging/kustomization.yaml
+++ b/cluster-scope/overlays/ocp-staging/kustomization.yaml
@@ -25,4 +25,8 @@ patches:
   - target:
       kind: Subscription
       group: operators.coreos.com
-    path: subscriptions/subscription-wave_patch.yaml
+    path: misc/sync-wave_patch.yaml
+
+  - target:
+      kind: Namespace
+    path: misc/sync-wave_patch.yaml

--- a/cluster-scope/overlays/ocp-staging/misc/sync-wave_patch.yaml
+++ b/cluster-scope/overlays/ocp-staging/misc/sync-wave_patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: does-not-matter
+kind: does-not-matter
+metadata:
+  name: does-not-matter
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"

--- a/cluster-scope/overlays/ocp-staging/subscriptions/subscription-wave_patch.yaml
+++ b/cluster-scope/overlays/ocp-staging/subscriptions/subscription-wave_patch.yaml
@@ -1,6 +1,0 @@
-apiVersion: operators.coreos.com/v1alpha1
-kind: Subscription
-metadata:
-  name: not-important
-  annotations:
-    argocd.argoproj.io/sync-wave: "-1"


### PR DESCRIPTION
We previously configured subscriptions to install in sync wave -1, but
this will fail if the subscription is to be installed into a namespace
that doesn't exist. We should also install namespaces in sync wave -1.
