### PR TITLE
Upgrade to latest 4.8 and set channel to fast-4.9

### DIFF
--- a/cluster-scope/overlays/ocp-staging/clusterversions/version.yaml
+++ b/cluster-scope/overlays/ocp-staging/clusterversions/version.yaml
@@ -1,0 +1,10 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+metadata:
+  name: version
+spec:
+  channel: fast-4.9
+  clusterID: 8986816a-6a42-4815-a5dd-e2f3e7eac95c
+  desiredUpdate:
+    version: 4.8.19
+    image: quay.io/openshift-release-dev/ocp-release@sha256:ac19c975be8b8a449dedcdd7520e970b1cc827e24042b8976bc0495da32c6b59

--- a/cluster-scope/overlays/ocp-staging/kustomization.yaml
+++ b/cluster-scope/overlays/ocp-staging/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 
   - certificates/api-certificate-letsencrypt.yaml
   - certificates/default-ingress-certificate.yaml
+  - clusterversions/version.yaml
   - externalsecrets/sso-clientsecret-moc.yaml
   - externalsecrets/rook-ceph-external-cluster-details.yaml
   - nodenetworkconfigurationpolicies/ceph-client-network.yaml


### PR DESCRIPTION
not sure if I should change the channel in this PR or not?

I set the channel in the web UI to fast-4.9 and then ran `oc adm ugrade` and it presented my several options to upgrade to and none of those were to a 4.9 version, so looks like the upgrade path includes 4.8.19

```
naved@naved-MS-7984:~/moc-apps/cluster-scope$ oc adm upgrade
Cluster version is 4.8.12

Updates:

VERSION IMAGE
4.8.13  quay.io/openshift-release-dev/ocp-release@sha256:5d396ad7d5f3cb527580c735e87dfd3b853bbb531e7f03e3a184d0accc223cdf
4.8.14  quay.io/openshift-release-dev/ocp-release@sha256:bf48faa639523b73131ec7c91637d5c94d33a4afe09ac8bdad672862f5e86ccb
4.8.15  quay.io/openshift-release-dev/ocp-release@sha256:92b684258b9f80dadce5b2f4efce0e110fb92b9f08f8837bdcbe7393c57d388f
4.8.17  quay.io/openshift-release-dev/ocp-release@sha256:1935b6c8277e351550bd7bfcc4d5df7c4ba0f7a90165c022e2ffbe789b15574a
4.8.18  quay.io/openshift-release-dev/ocp-release@sha256:321aae3d3748c589bc2011062cee9fd14e106f258807dc2d84ced3f7461160ea
4.8.19  quay.io/openshift-release-dev/ocp-release@sha256:ac19c975be8b8a449dedcdd7520e970b1cc827e24042b8976bc0495da32c6b59
```

![image](https://user-images.githubusercontent.com/20113064/141530319-d549ab2f-c0d6-4edf-9779-f4a5b91abff4.png)
