### PR TITLE
Upgrade staging cluster to 4.9.6

### DIFF
--- a/cluster-scope/overlays/ocp-staging/clusterversions/version.yaml
+++ b/cluster-scope/overlays/ocp-staging/clusterversions/version.yaml
@@ -6,5 +6,5 @@ spec:
   channel: fast-4.9
   clusterID: 8986816a-6a42-4815-a5dd-e2f3e7eac95c
   desiredUpdate:
-    version: 4.8.19
-    image: quay.io/openshift-release-dev/ocp-release@sha256:ac19c975be8b8a449dedcdd7520e970b1cc827e24042b8976bc0495da32c6b59
+    version: 4.9.6
+    image: quay.io/openshift-release-dev/ocp-release@sha256:c9f58ccb8a9085df4eeb23e21ca201d4c7d39bc434786d58a55381e13215a199

--- a/cluster-scope/overlays/ocp-staging/configmaps/admin-acks.yaml
+++ b/cluster-scope/overlays/ocp-staging/configmaps/admin-acks.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: admin-acks
+  namespace: openshift-config
+data:
+  ack-4.8-kube-1.22-api-removals-in-4.9: "true"

--- a/cluster-scope/overlays/ocp-staging/kustomization.yaml
+++ b/cluster-scope/overlays/ocp-staging/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - certificates/api-certificate-letsencrypt.yaml
   - certificates/default-ingress-certificate.yaml
   - clusterversions/version.yaml
+  - configmaps/admin-acks.yaml
   - externalsecrets/sso-clientsecret-moc.yaml
   - externalsecrets/rook-ceph-external-cluster-details.yaml
   - nodenetworkconfigurationpolicies/ceph-client-network.yaml


### PR DESCRIPTION
Do I manually ack the upgrade by running this?
```
oc -n openshift-config patch cm admin-acks --patch '{"data":{"ack-4.8-kube-1.22-api-removals-in-4.9":"true"}}' --type=merge
```
