### PR TITLE
Install mettallb on ocp-staging

### DIFF
--- a/cluster-scope/base/core/namespaces/metallb-system/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/metallb-system/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: metallb-system
+resources:
+- namespace.yaml

--- a/cluster-scope/base/core/namespaces/metallb-system/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/metallb-system/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: metallb-system
+spec: {}

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/metallb/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/metallb/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: metallb-system
+resources:
+- operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/metallb/operatorgroup.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/metallb/operatorgroup.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: metallb-operator
+  namespace: metallb-system
+spec:
+  targetNamespaces:
+  - metallb-system

--- a/cluster-scope/base/operators.coreos.com/subscriptions/metallb/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/metallb/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/metallb/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/metallb/subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: metallb-operator-sub
+  namespace: metallb-system
+spec:
+  channel: "4.9"
+  name: metallb-operator
+  source: community-operators
+  sourceNamespace: openshift-marketplace

--- a/cluster-scope/bundles/metallb/kustomization.yaml
+++ b/cluster-scope/bundles/metallb/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base/core/namespaces/metallb-system/
+  - ../../base/operators.coreos.com/operatorgroups/metallb/
+  - ../../base/operators.coreos.com/subscriptions/metallb/

--- a/cluster-scope/overlays/ocp-staging/kustomization.yaml
+++ b/cluster-scope/overlays/ocp-staging/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ../../bundles/nmstate
   - ../../bundles/node-labeler
   - ../../bundles/ocs
+  - ../../bundles/metallb
 
   - certificates/api-certificate-letsencrypt.yaml
   - certificates/default-ingress-certificate.yaml


### PR DESCRIPTION
create namespace, operatorgroup and subscription, and put that all in a bundle

https://docs.openshift.com/container-platform/4.9/networking/metallb/metallb-operator-install.html

should be merged after the cluster upgrades to 4.9