### PR TITLE
Deploy metallb on ocp-staging

### DIFF
--- a/app-of-apps/envs/ocp-staging/kustomization.yaml
+++ b/app-of-apps/envs/ocp-staging/kustomization.yaml
@@ -5,5 +5,6 @@ resources:
 - cluster-scope
 - external-secrets
 - node-labeler
+- metallb
 
 nameSuffix: -ocp-staging

--- a/app-of-apps/envs/ocp-staging/metallb/application.yaml
+++ b/app-of-apps/envs/ocp-staging/metallb/application.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: metallb
+spec:
+  destination:
+    name: ocp-staging
+    namespace: open-cluster-management-agent
+  project: mocops
+  source:
+    path: metallb/overlays/ocp-staging
+    repoURL: https://github.com/CCI-MOC/moc-apps.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - Validate=false
+    - ApplyOutOfSyncOnly=true

--- a/app-of-apps/envs/ocp-staging/metallb/kustomization.yaml
+++ b/app-of-apps/envs/ocp-staging/metallb/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- application.yaml

--- a/metallb/base/kustomization.yaml
+++ b/metallb/base/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: metallb-system
+commonLabels:
+  app: metallb
+
+resources:
+  - metallb.yaml

--- a/metallb/base/metallb.yaml
+++ b/metallb/base/metallb.yaml
@@ -1,0 +1,4 @@
+apiVersion: metallb.io/v1beta1
+kind: MetalLB
+metadata:
+  name: metallb

--- a/metallb/overlays/ocp-staging/addresspool.yaml
+++ b/metallb/overlays/ocp-staging/addresspool.yaml
@@ -1,0 +1,8 @@
+apiVersion: metallb.io/v1alpha1
+kind: AddressPool
+metadata:
+  name: csail-10
+spec:
+  protocol: layer2
+  addresses:
+  - 128.52.60.50-128.52.60.60

--- a/metallb/overlays/ocp-staging/kustomization.yaml
+++ b/metallb/overlays/ocp-staging/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: metallb-system
+commonLabels:
+  app: metallb
+
+resources:
+  - ../../base
+  - addresspool.yaml


### PR DESCRIPTION
This creates an app-of-app for metallb

and then creates an instance of it for ocp-staging and configures it.

https://docs.openshift.com/container-platform/4.9/networking/metallb/metallb-operator-install.html#nw-metallb-operator-initial-config_metallb-operator-install
https://docs.openshift.com/container-platform/4.9/networking/metallb/metallb-configure-address-pools.html#metallb-configure-address-pools

depends on #102 