### PR TITLE
Deploy openshift virtualization operator on ocp-staging

### DIFF
--- a/cluster-scope/bundles/cnv/kustomization.yaml
+++ b/cluster-scope/bundles/cnv/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../base/core/namespaces/openshift-cnv
-  - ../base/operators.coreos.com/operatorgroups/openshift-cnv
-  - ../base/operators.coreos.com/subscriptions/kubevirt-hyperconverged
+  - ../../base/core/namespaces/openshift-cnv
+  - ../../base/operators.coreos.com/operatorgroups/openshift-cnv
+  - ../../base/operators.coreos.com/subscriptions/kubevirt-hyperconverged

--- a/cluster-scope/overlays/ocp-staging/hyperconverged/kubevirt-hyperconverged.yaml
+++ b/cluster-scope/overlays/ocp-staging/hyperconverged/kubevirt-hyperconverged.yaml
@@ -1,0 +1,6 @@
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
+metadata:
+  name: kubevirt-hyperconverged
+  namespace: openshift-cnv
+spec:

--- a/cluster-scope/overlays/ocp-staging/kustomization.yaml
+++ b/cluster-scope/overlays/ocp-staging/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../common
 
+  - ../../bundles/cnv
   - ../../bundles/nmstate
   - ../../bundles/node-labeler
   - ../../bundles/ocs
@@ -14,6 +15,7 @@ resources:
   - configmaps/admin-acks.yaml
   - externalsecrets/sso-clientsecret-moc.yaml
   - externalsecrets/rook-ceph-external-cluster-details.yaml
+  - hyperconverged/kubevirt-hyperconverged.yaml
   - nodenetworkconfigurationpolicies/ceph-client-network.yaml
 
 patches:


### PR DESCRIPTION
Should this be deployed by it's own app or can we do it with the cluster-scope app?

This is based on the document here: https://docs.openshift.com/container-platform/4.9/virt/install/installing-virt-cli.html#virt-deploying-operator-cli_installing-virt-cli