### PR TITLE
Add missing operatorgroup for grafana operator in cs6620-fall21-deployverticalpod

### DIFF
--- a/cluster-scope/base/operators.coreos.com/operatorgroups/cs6620-fall21-deployverticalpod/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/cs6620-fall21-deployverticalpod/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: cs6620-fall21-deployverticalpod
+resources:
+- operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/cs6620-fall21-deployverticalpod/operatorgroup.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/cs6620-fall21-deployverticalpod/operatorgroup.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: cs6620-fall21-deployverticalpod
+  namespace: cs6620-fall21-deployverticalpod
+spec:
+  targetNamespaces:
+  - cs6620-fall21-deployverticalpod

--- a/cluster-scope/overlays/ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/ocp-prod/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - ../../base/core/namespaces/netbox
   - ../../base/core/namespaces/openshift-nfd
   - ../../base/nvidia.com/clusterpolicy/gpu-cluster-policy
+  - ../../base/operators.coreos.com/operatorgroups/cs6620-fall21-deployverticalpod
   - ../../base/operators.coreos.com/operatorgroups/openshift-nfd
   - ../../base/operators.coreos.com/subscriptions/crunchy-postgres
   - ../../base/operators.coreos.com/subscriptions/gpu-operator-certified


### PR DESCRIPTION
We deployed the Grafana operator for the
cs6620-fall21-deployverticalpod project back in 61f26e3, but we
neglected to create an OperatorGroup in the namespace so the operator
has so far failed to deploy.
