### PR TITLE
Remove my BU account from cluster-admins

### DIFF
--- a/cluster-scope/overlays/common/groups/cluster-admins.yaml
+++ b/cluster-scope/overlays/common/groups/cluster-admins.yaml
@@ -6,7 +6,6 @@ metadata:
     kustomize.config.k8s.io/behavior: replace
 users:
   - lkellogg@redhat.com
-  - lars@bu.edu
   - naved001@bu.edu
   - knikolla@bu.edu
   - robbaron@bu.edu


### PR DESCRIPTION
This way I have a non-admin account to use when necessary.
