### PR TITLE
Update Grafana to v4 channel

### DIFF
--- a/cluster-scope/components/operators.coreos.com/subscriptions/grafana-operator/subscription.yaml
+++ b/cluster-scope/components/operators.coreos.com/subscriptions/grafana-operator/subscription.yaml
@@ -3,7 +3,7 @@ kind: Subscription
 metadata:
   name: grafana-operator
 spec:
-  channel: alpha
+  channel: v4
   installPlanApproval: Automatic
   name: grafana-operator
   source: community-operators


### PR DESCRIPTION
The v3.x version that was previously installed is not compatible with
OpenShift 4.9 and was leading to errors such as:

```
$ oc get clusteroperator operator-lifecycle-manager -o json |
  jq '.status.conditions[]|select(.type == "Upgradeable")|.message'
"ClusterServiceVersions blocking cluster upgrade:
cs6620-fall21-deployverticalpod/grafana-operator.v3.10.3 is
incompatible with OpenShift minor versions greater than 4.8"
```
