### PR TITLE
Add moc-testing idp to ocp-staging

### DIFF
--- a/cluster-scope/overlays/ocp-staging/externalsecrets/sso-clientsecret-moc-testing.yaml
+++ b/cluster-scope/overlays/ocp-staging/externalsecrets/sso-clientsecret-moc-testing.yaml
@@ -1,0 +1,10 @@
+apiVersion: "kubernetes-client.io/v1"
+kind: ExternalSecret
+metadata:
+  name: sso-clientsecret-moc-testing
+  namespace: openshift-config
+spec:
+  backendType: secretsManager
+  data:
+    - key: cluster/ocp-staging/openshift-config/sso-clientsecret-moc-testing
+      name: clientSecret

--- a/cluster-scope/overlays/ocp-staging/kustomization.yaml
+++ b/cluster-scope/overlays/ocp-staging/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - clusterversions/version.yaml
   - configmaps/admin-acks.yaml
   - externalsecrets/sso-clientsecret-moc.yaml
+  - externalsecrets/sso-clientsecret-moc-testing.yaml
   - externalsecrets/rook-ceph-external-cluster-details.yaml
   - hyperconverged/kubevirt-hyperconverged.yaml
   - nodenetworkconfigurationpolicies/ceph-client-network.yaml

--- a/cluster-scope/overlays/ocp-staging/oauths/cluster_patch.yaml
+++ b/cluster-scope/overlays/ocp-staging/oauths/cluster_patch.yaml
@@ -20,3 +20,19 @@ spec:
         extraScopes: []
         issuer: https://sso.massopen.cloud/auth/realms/moc
       type: OpenID
+    - mappingMethod: claim
+      name: moc-testing
+      openID:
+        claims:
+          email:
+          - email
+          name:
+          - name
+          preferredUsername:
+          - preferred_username
+        clientID: moc-openshift-ocp-staging
+        clientSecret:
+          name: sso-clientsecret-moc-testing
+        extraScopes: []
+        issuer: https://sso.massopen.cloud/auth/realms/moc-testing
+      type: OpenID


### PR DESCRIPTION
This gives us the option of exploring different keycloak configuration
without impacting the production realm
