### PR TITLE
Introduce snapscheduler to moc-apps repository

### DIFF
--- a/app-of-apps/envs/ocp-staging/kustomization.yaml
+++ b/app-of-apps/envs/ocp-staging/kustomization.yaml
@@ -6,5 +6,6 @@ resources:
 - external-secrets
 - node-labeler
 - metallb
+- snapscheduler
 
 nameSuffix: -ocp-staging

--- a/app-of-apps/envs/ocp-staging/snapscheduler/application.yaml
+++ b/app-of-apps/envs/ocp-staging/snapscheduler/application.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: snapscheduler
+spec:
+  destination:
+    name: ocp-staging
+    namespace: open-cluster-management-agent
+  project: mocops
+  source:
+    path: snapscheduler
+    repoURL: https://github.com/CCI-MOC/moc-apps.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - Validate=false
+    - ApplyOutOfSyncOnly=true

--- a/app-of-apps/envs/ocp-staging/snapscheduler/kustomization.yaml
+++ b/app-of-apps/envs/ocp-staging/snapscheduler/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- application.yaml

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/snapshotschedules.snapscheduler.backube/customresourcedefinition.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/snapshotschedules.snapscheduler.backube/customresourcedefinition.yaml
@@ -1,0 +1,158 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  name: snapshotschedules.snapscheduler.backube
+spec:
+  group: snapscheduler.backube
+  names:
+    kind: SnapshotSchedule
+    listKind: SnapshotScheduleList
+    plural: snapshotschedules
+    singular: snapshotschedule
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.schedule
+          name: Schedule
+          type: string
+        - jsonPath: .spec.retention.expires
+          name: Max age
+          type: string
+        - jsonPath: .spec.retention.maxCount
+          name: Max num
+          type: integer
+        - jsonPath: .spec.disabled
+          name: Disabled
+          type: boolean
+        - jsonPath: .status.nextSnapshotTime
+          name: Next snapshot
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: SnapshotSchedule defines a schedule for taking automated snapshots of PVC(s)
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: SnapshotScheduleSpec defines the desired state of SnapshotSchedule
+              properties:
+                claimSelector:
+                  description: A filter to select which PVCs to snapshot via this schedule
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                          - key
+                          - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                  type: object
+                disabled:
+                  description: Indicates that this schedule should be temporarily disabled
+                  type: boolean
+                retention:
+                  description: Retention determines how long this schedule's snapshots will be kept.
+                  properties:
+                    expires:
+                      description: The length of time (time.Duration) after which a given Snapshot will be deleted.
+                      pattern: ^\d+(h|m|s)$
+                      type: string
+                    maxCount:
+                      description: The maximum number of snapshots to retain per PVC
+                      format: int32
+                      minimum: 1
+                      type: integer
+                  type: object
+                schedule:
+                  description: Schedule is a Cronspec specifying when snapshots should be taken. See https://en.wikipedia.org/wiki/Cron for a description of the format.
+                  pattern: ^((\d+|\*)(/\d+)?(\s+(\d+|\*)(/\d+)?){4}|@(hourly|daily|weekly|monthly|yearly))$
+                  type: string
+                snapshotTemplate:
+                  description: A template to customize the Snapshots.
+                  properties:
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: A list of labels that should be added to each Snapshot created by this schedule.
+                      type: object
+                    snapshotClassName:
+                      description: The name of the VolumeSnapshotClass to be used when creating Snapshots.
+                      type: string
+                  type: object
+              type: object
+            status:
+              description: SnapshotScheduleStatus defines the observed state of SnapshotSchedule
+              properties:
+                conditions:
+                  description: Conditions is a list of conditions related to operator reconciliation.
+                  items:
+                    description: Condition represents the state of the operator's reconciliation functionality.
+                    properties:
+                      lastHeartbeatTime:
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        description: ConditionType is the state of the operator's reconciliation functionality.
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                lastSnapshotTime:
+                  description: The time of the most recent snapshot taken by this schedule
+                  format: date-time
+                  type: string
+                nextSnapshotTime:
+                  description: The time of the next scheduled snapshot
+                  format: date-time
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ''
+    plural: ''
+  conditions: []
+  storedVersions: []

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/snapshotschedules.snapscheduler.backube/kustomization.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/snapshotschedules.snapscheduler.backube/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - customresourcedefinition.yaml

--- a/cluster-scope/base/core/namespaces/snapscheduler/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/snapscheduler/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: snapscheduler
+resources:
+- namespace.yaml

--- a/cluster-scope/base/core/namespaces/snapscheduler/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/snapscheduler/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: snapscheduler
+spec: {}

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/moc-snapscheduler-proxy/clusterrolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/moc-snapscheduler-proxy/clusterrolebinding.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: moc
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: snapscheduler
+    app.kubernetes.io/version: 2.1.0
+    helm.sh/chart: snapscheduler-2.1.0
+  name: moc-snapscheduler-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: moc-snapscheduler-proxy
+subjects:
+  - kind: ServiceAccount
+    name: moc-snapscheduler
+    namespace: snapscheduler

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/moc-snapscheduler-proxy/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/moc-snapscheduler-proxy/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - clusterrolebinding.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/moc-snapscheduler/clusterrolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/moc-snapscheduler/clusterrolebinding.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: moc
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: snapscheduler
+    app.kubernetes.io/version: 2.1.0
+    helm.sh/chart: snapscheduler-2.1.0
+  name: moc-snapscheduler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: moc-snapscheduler
+subjects:
+  - kind: ServiceAccount
+    name: moc-snapscheduler
+    namespace: snapscheduler

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/moc-snapscheduler/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/moc-snapscheduler/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - clusterrolebinding.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/moc-snapscheduler-metrics-reader/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/moc-snapscheduler-metrics-reader/clusterrole.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: moc
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: snapscheduler
+    app.kubernetes.io/version: 2.1.0
+    helm.sh/chart: snapscheduler-2.1.0
+  name: moc-snapscheduler-metrics-reader
+rules:
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/moc-snapscheduler-metrics-reader/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/moc-snapscheduler-metrics-reader/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - clusterrole.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/moc-snapscheduler-proxy/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/moc-snapscheduler-proxy/clusterrole.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: moc
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: snapscheduler
+    app.kubernetes.io/version: 2.1.0
+    helm.sh/chart: snapscheduler-2.1.0
+  name: moc-snapscheduler-proxy
+rules:
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/moc-snapscheduler-proxy/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/moc-snapscheduler-proxy/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - clusterrole.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/moc-snapscheduler/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/moc-snapscheduler/clusterrole.yaml
@@ -1,0 +1,57 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: moc
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: snapscheduler
+    app.kubernetes.io/version: 2.1.0
+    helm.sh/chart: snapscheduler-2.1.0
+  name: moc-snapscheduler
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - snapscheduler.backube
+    resources:
+      - snapshotschedules
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - snapscheduler.backube
+    resources:
+      - snapshotschedules/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - snapscheduler.backube
+    resources:
+      - snapshotschedules/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - snapshot.storage.k8s.io
+    resources:
+      - volumesnapshots
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/moc-snapscheduler/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/moc-snapscheduler/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - clusterrole.yaml

--- a/cluster-scope/bundles/snapscheduler/kustomization.yaml
+++ b/cluster-scope/bundles/snapscheduler/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base/core/namespaces/snapscheduler
+  - ../../base/apiextensions.k8s.io/customresourcedefinitions/snapshotschedules.snapscheduler.backube
+  - ../../base/rbac.authorization.k8s.io/clusterrolebindings/moc-snapscheduler-proxy
+  - ../../base/rbac.authorization.k8s.io/clusterrolebindings/moc-snapscheduler
+  - ../../base/rbac.authorization.k8s.io/clusterroles/moc-snapscheduler-metrics-reader
+  - ../../base/rbac.authorization.k8s.io/clusterroles/moc-snapscheduler-proxy
+  - ../../base/rbac.authorization.k8s.io/clusterroles/moc-snapscheduler

--- a/cluster-scope/overlays/ocp-staging/kustomization.yaml
+++ b/cluster-scope/overlays/ocp-staging/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ../../bundles/ocs
   - ../../bundles/metallb
   - ../../bundles/koku-metrics-operator
+  - ../../bundles/snapscheduler
 
   - certificates/api-certificate-letsencrypt.yaml
   - certificates/default-ingress-certificate.yaml

--- a/snapscheduler/apps/deployments/moc-snapscheduler/deployment.yaml
+++ b/snapscheduler/apps/deployments/moc-snapscheduler/deployment.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: moc
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: snapscheduler
+    app.kubernetes.io/version: 2.1.0
+    helm.sh/chart: snapscheduler-2.1.0
+  name: moc-snapscheduler
+  namespace: snapscheduler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: moc
+      app.kubernetes.io/name: snapscheduler
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: moc
+        app.kubernetes.io/name: snapscheduler
+        backube/snapscheduler-affinity: manager
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: backube/snapscheduler-affinity
+                      operator: In
+                      values:
+                        - manager
+                topologyKey: kubernetes.io/hostname
+              weight: 100
+      containers:
+        - args:
+            - --secure-listen-address=0.0.0.0:8443
+            - --upstream=http://127.0.0.1:8080/
+            - --logtostderr=true
+            - --v=10
+          image: quay.io/brancz/kube-rbac-proxy:v0.11.0
+          imagePullPolicy: IfNotPresent
+          name: kube-rbac-proxy
+          ports:
+            - containerPort: 8443
+              name: https
+          resources:
+            requests:
+              cpu: 10m
+              memory: 100Mi
+        - args:
+            - --health-probe-bind-address=:8081
+            - --metrics-bind-address=127.0.0.1:8080
+            - --leader-elect
+          command:
+            - /manager
+          image: quay.io/backube/snapscheduler:2.1.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          name: manager
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 10m
+              memory: 100Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: moc-snapscheduler
+      terminationGracePeriodSeconds: 10

--- a/snapscheduler/apps/deployments/moc-snapscheduler/kustomization.yaml
+++ b/snapscheduler/apps/deployments/moc-snapscheduler/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - deployment.yaml

--- a/snapscheduler/core/serviceaccounts/moc-snapscheduler/kustomization.yaml
+++ b/snapscheduler/core/serviceaccounts/moc-snapscheduler/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - serviceaccount.yaml

--- a/snapscheduler/core/serviceaccounts/moc-snapscheduler/serviceaccount.yaml
+++ b/snapscheduler/core/serviceaccounts/moc-snapscheduler/serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: moc
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: snapscheduler
+    app.kubernetes.io/version: 2.1.0
+    helm.sh/chart: snapscheduler-2.1.0
+  name: moc-snapscheduler
+  namespace: snapscheduler

--- a/snapscheduler/core/services/moc-snapscheduler-metrics/kustomization.yaml
+++ b/snapscheduler/core/services/moc-snapscheduler-metrics/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - service.yaml

--- a/snapscheduler/core/services/moc-snapscheduler-metrics/service.yaml
+++ b/snapscheduler/core/services/moc-snapscheduler-metrics/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: moc
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: snapscheduler
+    app.kubernetes.io/version: 2.1.0
+    helm.sh/chart: snapscheduler-2.1.0
+  name: moc-snapscheduler-metrics
+  namespace: snapscheduler
+spec:
+  ports:
+    - name: https
+      port: 8443
+      targetPort: https
+  selector:
+    app.kubernetes.io/instance: moc
+    app.kubernetes.io/name: snapscheduler

--- a/snapscheduler/kustomization.yaml
+++ b/snapscheduler/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - apps/deployments/moc-snapscheduler/deployment.yaml
+  - core/serviceaccounts/moc-snapscheduler/serviceaccount.yaml
+  - core/services/moc-snapscheduler-metrics/service.yaml
+  - rbac.authorization.k8s.io/rolebindings/moc-snapscheduler-leader-election/rolebinding.yaml
+  - rbac.authorization.k8s.io/roles/moc-snapscheduler-leader-election/role.yaml

--- a/snapscheduler/rbac.authorization.k8s.io/rolebindings/moc-snapscheduler-leader-election/kustomization.yaml
+++ b/snapscheduler/rbac.authorization.k8s.io/rolebindings/moc-snapscheduler-leader-election/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - rolebinding.yaml

--- a/snapscheduler/rbac.authorization.k8s.io/rolebindings/moc-snapscheduler-leader-election/rolebinding.yaml
+++ b/snapscheduler/rbac.authorization.k8s.io/rolebindings/moc-snapscheduler-leader-election/rolebinding.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: moc
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: snapscheduler
+    app.kubernetes.io/version: 2.1.0
+    helm.sh/chart: snapscheduler-2.1.0
+  name: moc-snapscheduler-leader-election
+  namespace: snapscheduler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: moc-snapscheduler-leader-election
+subjects:
+  - kind: ServiceAccount
+    name: moc-snapscheduler
+    namespace: snapscheduler

--- a/snapscheduler/rbac.authorization.k8s.io/roles/moc-snapscheduler-leader-election/kustomization.yaml
+++ b/snapscheduler/rbac.authorization.k8s.io/roles/moc-snapscheduler-leader-election/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - role.yaml

--- a/snapscheduler/rbac.authorization.k8s.io/roles/moc-snapscheduler-leader-election/role.yaml
+++ b/snapscheduler/rbac.authorization.k8s.io/roles/moc-snapscheduler-leader-election/role.yaml
@@ -1,0 +1,43 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/instance: moc
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: snapscheduler
+    app.kubernetes.io/version: 2.1.0
+    helm.sh/chart: snapscheduler-2.1.0
+  name: moc-snapscheduler-leader-election
+  namespace: snapscheduler
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - create
+      - patch

--- a/snapscheduler/src/.gitignore
+++ b/snapscheduler/src/.gitignore
@@ -1,0 +1,2 @@
+charts/
+manifests.yaml

--- a/snapscheduler/src/Makefile
+++ b/snapscheduler/src/Makefile
@@ -1,0 +1,21 @@
+# This requires halberd [1] and yq [2].
+#
+# [1]: https://github.com/larsks/halberd
+# [2]: https://kislyuk.github.io/yq/
+
+all: manifests.yaml
+
+manifests.yaml: kustomization.yaml
+	kustomize build --enable-helm | \
+		yq -y 'del(.metadata.creationTimestamp)' > $@ || { rm -f $@; exit 1; }
+
+clean:
+	rm -f manifests.yaml
+
+install: install-cluster-scoped install-namespaced
+
+install-cluster-scoped: manifests.yaml
+	halberd -d ../../cluster-scope/base -vvkgN $<
+
+install-namespaced: manifests.yaml
+	halberd -d .. -vvkgn $<

--- a/snapscheduler/src/kustomization.yaml
+++ b/snapscheduler/src/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: snapscheduler
+
+helmCharts:
+  - name: snapscheduler
+    releaseName: moc
+    repo: https://backube.github.io/helm-charts
+    includeCRDs: true


### PR DESCRIPTION
This PR introduces [snapscheduler][] to the moc-apps repository, and arranges
to install it on the ocp-staging cluster.

Snapscheduler manages PVC snapshots and snapshot retention policies.

[snapscheduler]: https://github.com/backube/snapscheduler

This PR includes the following commits:

- Add snapscheduler helm sources
- Add snapscheduler cluster-scoped resources
- Add snapscheduler namespaced resources
- Add snapscheduler bundle
- Add snapscheduler cluster-scoped resources to ocp-staging
- Add snapscheduler argocd app to ocp-staging

Part of cci-moc/ops-issues#473
