### PR TITLE
Fix bad apiversion in clusterrole introduced in #132

### DIFF
--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/curator-auth-proxy/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/curator-auth-proxy/clusterrole.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: curator-auth-proxy


### PR DESCRIPTION
This corrects apiversion rbac.authorization.k8s.io/v1beta to
rbac.authorization.k8s.io/v1.

Closes #134
