### PR TITLE
Add snapshot schedule for noobaa postgres pv

### DIFF
--- a/cluster-scope/overlays/ocp-staging/kustomization.yaml
+++ b/cluster-scope/overlays/ocp-staging/kustomization.yaml
@@ -21,6 +21,7 @@ resources:
   - externalsecrets/rook-ceph-external-cluster-details.yaml
   - hyperconverged/kubevirt-hyperconverged.yaml
   - nodenetworkconfigurationpolicies/ceph-client-network.yaml
+  - snapshotschedules/db-noobaa-db-pg-0.yaml
 
 patches:
   - path: apiservers/cluster_patch.yaml

--- a/cluster-scope/overlays/ocp-staging/snapshotschedules/db-noobaa-db-pg-0.yaml
+++ b/cluster-scope/overlays/ocp-staging/snapshotschedules/db-noobaa-db-pg-0.yaml
@@ -1,0 +1,15 @@
+apiVersion: snapscheduler.backube/v1
+kind: SnapshotSchedule
+metadata:
+  name: db-noobaa-db-pg
+spec:
+  claimSelector:
+    matchLabels:
+      app: noobaa
+      noobaa-db: postgres
+  retention:
+    maxCount: 8
+  schedule: "0 */6 * * *"
+  snapshotTemplate:
+    labels:
+      app: noobaa


### PR DESCRIPTION
Add a schedule to snapshot the noobaa postgres pv once every six hours and
keep up to eight snapshots.
