### PR TITLE
Add explicit namespace to snapshotschedule

### DIFF
--- a/cluster-scope/overlays/ocp-staging/snapshotschedules/db-noobaa-db-pg-0.yaml
+++ b/cluster-scope/overlays/ocp-staging/snapshotschedules/db-noobaa-db-pg-0.yaml
@@ -2,6 +2,7 @@ apiVersion: snapscheduler.backube/v1
 kind: SnapshotSchedule
 metadata:
   name: db-noobaa-db-pg
+  namespace: openshift-storage
 spec:
   claimSelector:
     matchLabels:


### PR DESCRIPTION
I neglected to include an explicit namespace in the noobaa
snapshotschedule, so it got deployed to the wrong namespace.
