### PR TITLE
Add netbox namespace to ocp-staging cluster

### DIFF
--- a/cluster-scope/overlays/common/kustomization.yaml
+++ b/cluster-scope/overlays/common/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../base/config.openshift.io/apiservers/cluster
   - ../../base/config.openshift.io/oauths/cluster
+  - ../../base/core/namespaces/netbox
   - ../../base/operator.openshift.io/ingresscontrollers/default
   - ../../base/operators.coreos.com/subscriptions/snapscheduler
   - ../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-rb

--- a/cluster-scope/overlays/ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/ocp-prod/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
   - ../../base/core/namespaces/cs6620-fall21-deployverticalpod
   - ../../base/core/namespaces/gpu-operator-resources
   - ../../base/core/namespaces/moc-projects
-  - ../../base/core/namespaces/netbox
   - ../../base/core/namespaces/openshift-nfd
   - ../../base/nvidia.com/clusterpolicy/gpu-cluster-policy
   - ../../base/operators.coreos.com/operatorgroups/cs6620-fall21-deployverticalpod


### PR DESCRIPTION
This moves the netbox namespace from overlays/ocp-prod to overlays/common.
