### PR TITLE
Rename bucket for s3 backups

### DIFF
--- a/netbox/overlays/ocp-prod/postgresclusters/netbox.yaml
+++ b/netbox/overlays/ocp-prod/postgresclusters/netbox.yaml
@@ -58,5 +58,5 @@ spec:
         s3:
           # see https://github.com/CrunchyData/postgres-operator/issues/2836
           endpoint: "rgw-j-vip.int.massopen.cloud:443"
-          bucket: netbox
+          bucket: netbox-backup
           region: default


### PR DESCRIPTION
In #145, I named the target bucket for s3 backups `netbox`, but upon
reflection this is too generic (what if we want another bucket from the
Ceph servers for netbox?), so I've updated our configuration to target
`netbox-backup` instead of `netbox`.
