### PR TITLE
Update secret names

### DIFF
--- a/netbox/overlays/ocp-prod/externalsecrets/netbox-backup.yaml
+++ b/netbox/overlays/ocp-prod/externalsecrets/netbox-backup.yaml
@@ -1,0 +1,13 @@
+apiVersion: "kubernetes-client.io/v1"
+kind: ExternalSecret
+metadata:
+  name: netbox-backup
+spec:
+  backendType: secretsManager
+  data:
+    - key: cluster/ocp-prod/netbox/netbox-backup
+      name: creds_json
+  template:
+    stringData:
+      AWS_ACCESS_KEY_ID: <%= JSON.parse(data.creds_json).AWS_ACCESS_KEY_ID %>
+      AWS_SECRET_ACCESS_KEY: <%= JSON.parse(data.creds_json).AWS_SECRET_ACCESS_KEY %>

--- a/netbox/overlays/ocp-prod/externalsecrets/netbox-s3-creds.yaml
+++ b/netbox/overlays/ocp-prod/externalsecrets/netbox-s3-creds.yaml
@@ -1,9 +1,0 @@
-apiVersion: "kubernetes-client.io/v1"
-kind: ExternalSecret
-metadata:
-  name: netbox-s3-creds
-spec:
-  backendType: secretsManager
-  data:
-    - key: cluster/ocp-prod/netbox/pgbackrest-s3-conf
-      name: s3.conf

--- a/netbox/overlays/ocp-prod/externalsecrets/pgbackrest-s3-conf.yaml
+++ b/netbox/overlays/ocp-prod/externalsecrets/pgbackrest-s3-conf.yaml
@@ -1,0 +1,15 @@
+apiVersion: "kubernetes-client.io/v1"
+kind: ExternalSecret
+metadata:
+  name: pgbackrest-s3-conf
+spec:
+  backendType: secretsManager
+  data:
+    - key: cluster/ocp-prod/netbox/netbox-backup
+      name: creds_json
+  template:
+    stringData:
+      s3.conf: |
+        [global]
+        repo2-s3-key=<%= JSON.parse(data.creds_json).AWS_ACCESS_KEY_ID %>
+        repo2-s3-key-secret=<%= JSON.parse(data.creds_json).AWS_SECRET_ACCESS_KEY %>

--- a/netbox/overlays/ocp-prod/kustomization.yaml
+++ b/netbox/overlays/ocp-prod/kustomization.yaml
@@ -6,9 +6,11 @@ commonLabels:
 
 resources:
   - ../../base
+
+  - externalsecrets/netbox-backup.yaml
   - externalsecrets/netbox-secret.yaml
   - externalsecrets/oauth2-secret.yaml
-  - externalsecrets/netbox-s3-creds.yaml
+  - externalsecrets/pgbackrest-s3-conf.yaml
   - postgresclusters/netbox.yaml
   - routes/netbox-api.yaml
   - services/netbox-auth.yaml

--- a/netbox/overlays/ocp-prod/postgresclusters/netbox.yaml
+++ b/netbox/overlays/ocp-prod/postgresclusters/netbox.yaml
@@ -29,7 +29,7 @@ spec:
       image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.35-0
       configuration:
         - secret:
-            name: netbox-s3-creds
+            name: pgbackrest-s3-conf
       global:
         # Note that retention-type defaults to "count", so a value of "7"
         # here means "keep 7 full backups".


### PR DESCRIPTION
Accidentally publishing secrets to GitHub meant looking more closely at the
secrets we're using and I decided we need to refactor a few things.

This PR makes the following three changes:

- Store credentials in AWS as a JSON secret value, and use a template to
  extract that into a simple `key: value` secret in case we want to use
  them in `envFrom` or `valueFrom` directives.

- Rather than storing the PGO `s3.conf` file literally in AWS, build it
  with a template using the values from the JSON secret.

- Using a secret naming scheme similar to that used by ODF (née OCS)
  when creating buckets and their associated secrets (so, name the secret
  for accessing the `netbox-backup` bucket `netbox-backup`.
