### PR TITLE
Configure Netbox object storage backend

### DIFF
--- a/netbox/overlays/ocp-prod/config/allow-anonymous-read.json
+++ b/netbox/overlays/ocp-prod/config/allow-anonymous-read.json
@@ -1,0 +1,17 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "PublicRead",
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": [
+                "s3:GetObject",
+                "s3:GetObjectVersion"
+            ],
+            "Resource": [
+                "arn:aws:s3:::BUCKET_NAME/*"
+            ]
+        }
+    ]
+}

--- a/netbox/overlays/ocp-prod/config/extra.py
+++ b/netbox/overlays/ocp-prod/config/extra.py
@@ -1,3 +1,5 @@
+import os
+
 CORS_ORIGIN_ALLOW_ALL = True
 LOGIN_REQUIRED = True
 REMOTE_AUTH_AUTO_CREATE_GROUPS = True
@@ -10,3 +12,20 @@ REMOTE_AUTH_HEADER = "HTTP_X_FORWARDED_PREFERRED_USERNAME"
 REMOTE_AUTH_STAFF_GROUPS = ["netbox-admins"]
 REMOTE_AUTH_SUPERUSER_GROUPS = ["netbox-admins"]
 SKIP_SUPERUSER = True
+
+# See:
+# - https://netbox.readthedocs.io/en/stable/configuration/optional-settings/#storage_backend
+# - https://django-storages.readthedocs.io/en/stable/backends/amazon-S3.html
+STORAGE_BACKEND = "storages.backends.s3boto3.S3Boto3Storage"
+STORAGE_CONFIG = {
+    "AWS_STORAGE_BUCKET_NAME": os.environ["BUCKET_NAME"],
+    "AWS_S3_REGION_NAME": os.environ["BUCKET_REGION"],
+    "AWS_S3_ADDRESSING_STYLE": "path",
+    "AWS_S3_ENDPOINT_URL": "https://{}:{}".format(
+        os.environ["BUCKET_HOST"], os.environ["BUCKET_PORT"]
+    ),
+    "AWS_S3_VERIFY": "/run/secrets/kubernetes.io/serviceaccount/service-ca.crt",
+    "AWS_S3_CUSTOM_DOMAIN": "s3-openshift-storage.apps.ocp-prod.massopen.cloud/{}".format(
+        os.environ["BUCKET_NAME"]
+    ),
+}

--- a/netbox/overlays/ocp-prod/deployments/netbox_config_patch.yaml
+++ b/netbox/overlays/ocp-prod/deployments/netbox_config_patch.yaml
@@ -31,6 +31,10 @@ spec:
           envFrom:
             - secretRef:
                 name: netbox-secret
+            - secretRef:
+                name: netbox-storage
+            - configMapRef:
+                name: netbox-storage
           volumeMounts:
             - name: netbox-config
               mountPath: /etc/netbox/config/extra.py
@@ -60,6 +64,10 @@ spec:
           envFrom:
             - secretRef:
                 name: netbox-secret
+            - secretRef:
+                name: netbox-storage
+            - configMapRef:
+                name: netbox-storage
           volumeMounts:
             - name: netbox-config
               mountPath: /etc/netbox/config/extra.py
@@ -89,11 +97,40 @@ spec:
           envFrom:
             - secretRef:
                 name: netbox-secret
+            - secretRef:
+                name: netbox-storage
+            - configMapRef:
+                name: netbox-storage
           volumeMounts:
             - name: netbox-config
               mountPath: /etc/netbox/config/extra.py
               subPath: extra.py
+      initContainers:
+        - name: set-bucket-policy
+          image: docker.io/amazon/aws-cli:latest
+          envFrom:
+            - secretRef:
+                name: netbox-storage
+            - configMapRef:
+                name: netbox-storage
+          volumeMounts:
+            - name: netbox-bucket-policy
+              mountPath: /policy
+          command:
+            - bash
+            - -c
+            - |
+              sed "s/BUCKET_NAME/${BUCKET_NAME}/g" /policy/allow-anonymous-read.json > /tmp/policy.json
+              while :; do
+                aws --ca-bundle /run/secrets/kubernetes.io/serviceaccount/service-ca.crt \
+                  --endpoint https://${BUCKET_HOST} s3api put-bucket-policy \
+                  --bucket ${BUCKET_NAME} --policy file:///tmp/policy.json && break
+                sleep 5
+              done
       volumes:
         - name: netbox-config
           configMap:
             name: netbox-config
+        - name: netbox-bucket-policy
+          configMap:
+            name: netbox-bucket-policy

--- a/netbox/overlays/ocp-prod/kustomization.yaml
+++ b/netbox/overlays/ocp-prod/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - externalsecrets/netbox-secret.yaml
   - externalsecrets/oauth2-secret.yaml
   - externalsecrets/pgbackrest-s3-conf.yaml
+  - objectbucketclaims/netbox-storage.yaml
   - postgresclusters/netbox.yaml
   - routes/netbox-api.yaml
   - services/netbox-auth.yaml
@@ -22,6 +23,9 @@ configMapGenerator:
   - name: oauth2-config
     envs:
       - config/oauth2.env
+  - name: netbox-bucket-policy
+    files:
+      - config/allow-anonymous-read.json
 
 patches:
   - path: deployments/netbox_oauth_patch.yaml

--- a/netbox/overlays/ocp-prod/objectbucketclaims/netbox-storage.yaml
+++ b/netbox/overlays/ocp-prod/objectbucketclaims/netbox-storage.yaml
@@ -1,0 +1,9 @@
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: netbox-storage
+spec:
+  additionalConfig:
+    maxSize: 5G
+  generateBucketName: netbox-storage
+  storageClassName: openshift-storage.noobaa.io


### PR DESCRIPTION
Netbox allows us to attach images to objects, which may be useful to
help identify devices/ports/etc. By default these attachments are
stored on the filesystem, but this complicates replicas and failover.

This commit configures the S3 storage backend.  Specifically:

- It allocates object storage through an `ObjectBucketClaim`
- It uses the `Secret` and `ConfigMap` produced by the
  `ObjectBucketClaim` to configure the netbox `STORAGE_CONFIGURATION`
  option.
- It adds an `initContainer` to the Netbox `Deployment` that takes
  care of setting an appropriate policy on the object bucket to permit
  anonymous READ access.

Closes cci-moc/ops-issues#444