### PR TITLE
Use default strategy for Netbox deployment

### DIFF
--- a/netbox/base/deployments/netbox.yaml
+++ b/netbox/base/deployments/netbox.yaml
@@ -6,8 +6,6 @@ metadata:
     component: netbox
 spec:
   replicas: 1
-  strategy:
-    type: Recreate
   selector:
     matchLabels:
       component: netbox


### PR DESCRIPTION
The netbox `Deployment` was configured to use the `Recreate` strategy,
which means that a replacement pod can't start until the existing
pod has terminated. This is unnecessary and slows down the process of
rolling out configuration changes.

This commit removes the explicit `strategy.type` setting from the
`Deployment`.