### PR TITLE
Upgrade Netbox to v3.1

### DIFF
--- a/netbox/base/kustomization.yaml
+++ b/netbox/base/kustomization.yaml
@@ -18,4 +18,4 @@ resources:
 images:
   - name: netbox
     newName: quay.io/netboxcommunity/netbox
-    newTag: v3.0-ldap
+    newTag: v3.1

--- a/netbox/overlays/ocp-prod/kustomization.yaml
+++ b/netbox/overlays/ocp-prod/kustomization.yaml
@@ -30,8 +30,3 @@ patches:
   - path: deployments/netbox_oauth_patch.yaml
   - path: deployments/netbox_config_patch.yaml
   - path: routes/netbox_patch.yaml
-
-images:
-  - name: quay.io/netboxcommunity/netbox
-    newName: quay.io/larsks/netbox
-    newTag: remote-group-autocreate-1.4.1-4


### PR DESCRIPTION
Replace our customized version of the 3.0 container image with the upstream
3.1 image.

Closes cci-moc/ops-issues#519
