### PR TITLE
Support per-cluster cluster admins

### DIFF
--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-rb/clusterrolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-rb/clusterrolebinding.yaml
@@ -11,3 +11,6 @@ subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group
     name: cluster-admins
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: local-cluster-admins

--- a/cluster-scope/base/user.openshift.io/groups/local-cluster-admins/group.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/local-cluster-admins/group.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+  name: local-cluster-admins
+users: []

--- a/cluster-scope/base/user.openshift.io/groups/local-cluster-admins/kustomization.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/local-cluster-admins/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- group.yaml

--- a/cluster-scope/overlays/common/kustomization.yaml
+++ b/cluster-scope/overlays/common/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-rb
   - ../../base/rbac.authorization.k8s.io/clusterrolebindings/self-provisioners
   - ../../base/user.openshift.io/groups/cluster-admins
+  - ../../base/user.openshift.io/groups/local-cluster-admins
   - ../../bundles/cert-manager
   - ../../bundles/external-secrets
 

--- a/cluster-scope/overlays/ocp-staging/groups/local-cluster-admins.yaml
+++ b/cluster-scope/overlays/ocp-staging/groups/local-cluster-admins.yaml
@@ -1,0 +1,8 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+  name: local-cluster-admins
+  annotations:
+    kustomize.config.k8s.io/behavior: replace
+users:
+  - mhaley@redhat.com

--- a/cluster-scope/overlays/ocp-staging/kustomization.yaml
+++ b/cluster-scope/overlays/ocp-staging/kustomization.yaml
@@ -27,6 +27,7 @@ patches:
   - path: apiservers/cluster_patch.yaml
   - path: oauths/cluster_patch.yaml
   - path: groups/koku-metrics-operator-admin.yaml
+  - path: groups/local-cluster-admins.yaml
 
   - target:
       kind: ClusterIssuer


### PR DESCRIPTION
Define a local-cluster-admins groups for which we maintain per-overlay
membership. This allows us to grant cluster-admins access to a single
cluster in a convenient manner.
