### PR TITLE
Make lmcgann a cluster admin for ocp-staging

### DIFF
--- a/cluster-scope/overlays/ocp-staging/groups/local-cluster-admins.yaml
+++ b/cluster-scope/overlays/ocp-staging/groups/local-cluster-admins.yaml
@@ -6,3 +6,4 @@ metadata:
     kustomize.config.k8s.io/behavior: replace
 users:
   - mhaley@redhat.com
+  - lmcgann@redhat.com


### PR DESCRIPTION
In order to test out the account management tooling leo needs
administrative access to a cluster. ocp-staging seems like a good place for
this.
