### PR TITLE
Move image registry configuration to common overlay

### DIFF
--- a/cluster-scope/overlays/common/kustomization.yaml
+++ b/cluster-scope/overlays/common/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - ../../base/user.openshift.io/groups/local-cluster-admins
   - ../../bundles/cert-manager
   - ../../bundles/external-secrets
+  - ../../bundles/image-registry
 
   - machineconfigs/99-master-ssh.yaml
   - machineconfigs/99-worker-ssh.yaml

--- a/cluster-scope/overlays/ocp-prod/kustomization.yaml
+++ b/cluster-scope/overlays/ocp-prod/kustomization.yaml
@@ -16,7 +16,6 @@ resources:
   - ../../base/rbac.authorization.k8s.io/clusterroles/project-maker
 
   - ../../bundles/cnv
-  - ../../bundles/image-registry
   - ../../bundles/metallb
   - ../../bundles/ocs
   - ../../bundles/ray-clusters


### PR DESCRIPTION
Previously, the registry was only enabled on ocp-prod.
