### PR TITLE
Set correct namespace for ray-operator role and rolebinding.

### DIFF
--- a/cluster-scope/base/rbac.authorization.k8s.io/rolebindings/ray-operator-rolebinding/rolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/rolebindings/ray-operator-rolebinding/rolebinding.yaml
@@ -2,6 +2,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ray-operator-rolebinding
+  namespace: remote-sensing
 subjects:
 - kind: ServiceAccount
   name: ray-operator-serviceaccount

--- a/cluster-scope/base/rbac.authorization.k8s.io/roles/ray-operator-role/role.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/roles/ray-operator-role/role.yaml
@@ -2,6 +2,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ray-operator-role
+  namespace: remote-sensing
 rules:
 - apiGroups: ["", "cluster.ray.io"]
   resources: ["rayclusters", "rayclusters/finalizers", "rayclusters/status", "pods", "pods/exec", "services"]


### PR DESCRIPTION
Without it these ended up in `open-cluster-management-agent` namespace.

cc: @acemaster 