### PR TITLE
Omit image in postgrescluster specs

### DIFF
--- a/netbox/overlays/ocp-prod/postgresclusters/netbox.yaml
+++ b/netbox/overlays/ocp-prod/postgresclusters/netbox.yaml
@@ -3,7 +3,6 @@ kind: PostgresCluster
 metadata:
   name: netbox
 spec:
-  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-13.4-1
   postgresVersion: 13
   instances:
     - name: pgha1
@@ -26,7 +25,6 @@ spec:
                   postgres-operator.crunchydata.com/instance-set: pgha1
   backups:
     pgbackrest:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.35-0
       configuration:
         - secret:
             name: pgbackrest-s3-conf

--- a/netbox/overlays/ocp-staging/postgresclusters/netbox.yaml
+++ b/netbox/overlays/ocp-staging/postgresclusters/netbox.yaml
@@ -3,7 +3,6 @@ kind: PostgresCluster
 metadata:
   name: netbox
 spec:
-  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-13.4-1
   postgresVersion: 13
   instances:
     - name: pgha1
@@ -26,7 +25,6 @@ spec:
                   postgres-operator.crunchydata.com/instance-set: pgha1
   backups:
     pgbackrest:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.35-0
       global:
         # Note that retention-type defaults to "count", so a value of "7"
         # here means "keep 7 full backups".


### PR DESCRIPTION
The image we specified does not have the server sub-command.

```
naved@Naveds-MacBook-Pro ~ % oc logs netbox-pgha1-bc2z-0 pgbackrest
ERROR: [048]: invalid command 'server'
```
due to which the backups don't work.

and acccording to the documentation[1] if we don't specify the image it will
get that from the operator.

[1] https://access.crunchydata.com/documentation/postgres-operator/5.1.0/references/crd/#postgrescluster

closes #592