### PR TITLE
Set Image tag to Commit ID instead of Latest

### DIFF
--- a/netbox/overlays/ocp-prod/kustomization.yaml
+++ b/netbox/overlays/ocp-prod/kustomization.yaml
@@ -32,7 +32,7 @@ configMapGenerator:
 images:
   - name: quay.io/netboxcommunity/netbox
     newName: quay.io/hakasapl/netbox-moc-plugins
-    newTag: main
+    newTag: e7d3c8e
 
 patches:
   - path: deployments/netbox_oauth_patch.yaml


### PR DESCRIPTION
main reflects the main branch here: https://github.com/CCI-MOC/netbox-topology

There is also a dev tag now for the dev branch in that repo. Main will only be updated for production.