### PR TITLE
Add xdmod service account to prometheus-k8s clusterrole

### DIFF
--- a/cluster-scope/overlays/ocp-staging/clusterrolebindings/xdmod-reader-cluster-monitor/clusterrolebinding.yaml
+++ b/cluster-scope/overlays/ocp-staging/clusterrolebindings/xdmod-reader-cluster-monitor/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: xdmod-reader-cluster-monitor
+subjects:
+- kind: ServiceAccount
+  name: xdmod-reader
+  namespace: xdmod-tzumainn
+roleRef:
+  kind: ClusterRole
+  name: cluster-monitoring-view
+  apiGroup: rbac.authorization.k8s.io

--- a/cluster-scope/overlays/ocp-staging/clusterrolebindings/xdmod-reader-cluster-monitor/kustomization.yaml
+++ b/cluster-scope/overlays/ocp-staging/clusterrolebindings/xdmod-reader-cluster-monitor/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- clusterrolebinding.yaml

--- a/cluster-scope/overlays/ocp-staging/kustomization.yaml
+++ b/cluster-scope/overlays/ocp-staging/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   - certificates/api-certificate-letsencrypt.yaml
   - certificates/default-ingress-certificate.yaml
   - clusterversions/version.yaml
+  - clusterrolebindings/xdmod-reader-cluster-monitor
   - configmaps/admin-acks.yaml
   - externalsecrets/sso-clientsecret-moc.yaml
   - externalsecrets/sso-clientsecret-moc-testing.yaml


### PR DESCRIPTION
I am not entirely sure if this is what we need, I am going off of the openshift documentation [1]  talking about the `/metrics` endpoint.

A redhat solution [2] about OCP3 talks about adding the service account to a clusterrole called `cluster-monitoring-view`. I looked at it for our cluster and saw the following which I don't think would work. It's OCP 3 anyway, but I wanted to mention it regardless.
```
naved@Naveds-MacBook-Pro ocp-staging % oc get clusterrole cluster-monitoring-view -o yaml |oc neat
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: cluster-monitoring-view
rules:
- apiGroups:
  - ""
  resources:
  - namespaces
  verbs:
  - get
```

[1] https://docs.openshift.com/container-platform/4.9/monitoring/managing-metrics.html#understanding-metrics_managing-metrics
[2] https://access.redhat.com/solutions/4496871

Closes: cci-moc/ops-issues#625