### PR TITLE
Increase the size of prometheus PV

### DIFF
--- a/cluster-scope/overlays/ocp-prod/configmaps/cluster-monitoring-config.yaml
+++ b/cluster-scope/overlays/ocp-prod/configmaps/cluster-monitoring-config.yaml
@@ -4,7 +4,7 @@ prometheusK8s:
       storageClassName: ocs-external-storagecluster-ceph-rbd
       resources:
         requests:
-          storage: 50Gi
+          storage: 100Gi
 alertmanagerMain:
   volumeClaimTemplate:
     spec:


### PR DESCRIPTION
As we add more nodes and pods we need to allocate more space or decrease the retention period for metrics. Looks like 50G may not be sufficient for our cluster. One of the recommendation by red hat support person was to allocate more storage. 

I cleared the old logs by setting the retention to 10 minutes briefly which I then reset it back to 15 days.

[ ] https://docs.openshift.com/container-platform/4.9/scalability_and_performance/scaling-cluster-monitoring-operator.html#prometheus-database-storage-requirements_cluster-monitoring-operator

closes: https://github.com/CCI-MOC/ops-issues/issues/559