### PR TITLE
Deploy openshift-acct-mgt to ocp-staging

### DIFF
--- a/acct-mgt/base/configmaps.yaml
+++ b/acct-mgt/base/configmaps.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: acct-mgt-configmap
+data:
+  ACCT_MGT_ADMIN_USERNAME: "admin"
+  ACCT_MGT_QUOTA_DEF_FILE: "/app/quota/quotas.json"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: acct-mgt-quota-configmap
+data:
+  quotas.json: |
+    {
+      ":requests.cpu":                  { "base": 2, "coefficient": 0 },
+      ":requests.memory":               { "base": 2, "coefficient": 0 },
+      ":limits.cpu":                    { "base": 2, "coefficient": 0 },
+      ":limits.memory":                 { "base": 2, "coefficient": 0 },
+      ":requests.storage":              { "base": 2, "coefficient": 0, "units": "Gi" },
+      ":limits.storage":                { "base": 2, "coefficient": 0, "units": "Gi" },
+      ":requests.ephemeral-storage":    { "base": 2, "coefficient": 8, "units": "Gi" },
+      ":limits.ephemeral-storage":      { "base": 2, "coefficient": 8, "units": "Gi" },
+      ":persistentvolumeclaims":        { "base": 2, "coefficient": 0 },
+      ":replicationcontrollers":        { "base": 2, "coefficient": 0 },
+      ":resourcequotas":                { "base": 5, "coefficient": 0 },
+      ":services":                      { "base": 4, "coefficient": 0 },
+      ":services.loadbalancers":        { "base": 2, "coefficient": 0 },
+      ":services.nodeports":            { "base": 2, "coefficient": 0 },
+      ":secrets":                       { "base": 4, "coefficient": 0 },
+      ":configmaps":                    { "base": 4, "coefficient": 0 },
+      ":openshift.io/imagestreams":     { "base": 2, "coefficient": 0 },
+      "BestEffort:pods":                { "base": 2, "coefficient": 2 },
+      "NotBestEffort:pods":             { "base": 2, "coefficient": 2 },
+      "NotBestEffort:requests.memory":  { "base": 2, "coefficient": 4, "units": "Gi"  },
+      "NotBestEffort:limits.memory":    { "base": 2, "coefficient": 4, "units": "Gi"  },
+      "NotBestEffort:requests.cpu":     { "base": 2, "coefficient": 2 },
+      "NotBestEffort:limits.cpu":       { "base": 2, "coefficient": 2 },
+      "Terminating:pods":               { "base": 2, "coefficient": 2 },
+      "Terminating:requests.memory":    { "base": 2, "coefficient": 4, "units": "Gi"  },
+      "Terminating:limits.memory":      { "base": 2, "coefficient": 4, "units": "Gi"  },
+      "Terminating:requests.cpu":       { "base": 2, "coefficient": 2 },
+      "Terminating:limits.cpu":         { "base": 2, "coefficient": 2 },
+      "NotTerminating:pods":            { "base": 2, "coefficient": 2 },
+      "NotTerminating:requests.memory": { "base": 2, "coefficient": 4, "units": "Gi"  },
+      "NotTerminating:limits.memory":   { "base": 2, "coefficient": 4, "units": "Gi"  },
+      "NotTerminating:requests.cpu":    { "base": 2, "coefficient": 2 },
+      "NotTerminating:limits.cpu":      { "base": 2, "coefficient": 2 }
+    }

--- a/acct-mgt/base/deployment.yaml
+++ b/acct-mgt/base/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: acct-mgt
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: acct-mgt
+          envFrom:
+            - secretRef:
+                name: acct-mgt-secrets
+            - configMapRef:
+                name: acct-mgt-configmap
+          image: "ghcr.io/cci-moc/openshift-acct-mgt:master"
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: quota-vol
+              mountPath: /app/quota
+              readOnly: true
+      volumes:
+        - name: quota-vol
+          configMap:
+            name: acct-mgt-quota-configmap
+      serviceAccountName: acct-mgt-serviceaccount
+      automountServiceAccountToken: true

--- a/acct-mgt/base/kustomization.yaml
+++ b/acct-mgt/base/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: acct-mgt
+commonLabels:
+  app: acct-mgt
+resources:
+  - configmaps.yaml
+  - deployment.yaml
+  - route.yaml
+  - service.yaml
+  - serviceaccount.yaml

--- a/acct-mgt/base/route.yaml
+++ b/acct-mgt/base/route.yaml
@@ -1,0 +1,12 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: acct-mgt
+spec:
+  port:
+    targetPort: http
+  to:
+    kind: Service
+    name: acct-mgt
+  tls:
+    termination: edge

--- a/acct-mgt/base/service.yaml
+++ b/acct-mgt/base/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: acct-mgt
+spec:
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: http
+  selector:
+    app: acct-mgt

--- a/acct-mgt/base/serviceaccount.yaml
+++ b/acct-mgt/base/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: acct-mgt-serviceaccount

--- a/acct-mgt/overlays/ocp-staging/externalsecrets.yaml
+++ b/acct-mgt/overlays/ocp-staging/externalsecrets.yaml
@@ -1,0 +1,9 @@
+apiVersion: "kubernetes-client.io/v1"
+kind: ExternalSecret
+metadata:
+  name: acct-mgt-secrets
+spec:
+  backendType: secretsManager
+  data:
+    - key: cluster/ocp-staging/acct-mgt/admin_password
+      name: ACCT_MGT_ADMIN_PASSWORD

--- a/acct-mgt/overlays/ocp-staging/kustomization.yaml
+++ b/acct-mgt/overlays/ocp-staging/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: acct-mgt
+resources:
+  - ../../base
+  - externalsecrets.yaml
+patchesStrategicMerge:
+  - patches/configmap_patch.yaml

--- a/acct-mgt/overlays/ocp-staging/patches/configmap_patch.yaml
+++ b/acct-mgt/overlays/ocp-staging/patches/configmap_patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: acct-mgt-configmap
+data:
+  ACCT_MGT_IDENTITY_PROVIDER: "moc-testing"

--- a/app-of-apps/envs/ocp-staging/acct-mgt/application.yaml
+++ b/app-of-apps/envs/ocp-staging/acct-mgt/application.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: acct-mgt
+spec:
+  destination:
+    name: ocp-staging
+    namespace: acct-mgt
+  project: mocops
+  source:
+    path: acct-mgt/overlays/ocp-staging
+    repoURL: https://github.com/CCI-MOC/moc-apps.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - Validate=false
+    - ApplyOutOfSyncOnly=true

--- a/app-of-apps/envs/ocp-staging/acct-mgt/kustomization.yaml
+++ b/app-of-apps/envs/ocp-staging/acct-mgt/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - application.yaml

--- a/app-of-apps/envs/ocp-staging/kustomization.yaml
+++ b/app-of-apps/envs/ocp-staging/kustomization.yaml
@@ -8,5 +8,6 @@ resources:
 - metallb
 - netbox
 - volsync
+- acct-mgt
 
 nameSuffix: -ocp-staging

--- a/cluster-scope/base/core/namespaces/acct-mgt/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/acct-mgt/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: acct-mgt
+resources:
+- namespace.yaml

--- a/cluster-scope/base/core/namespaces/acct-mgt/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/acct-mgt/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: acct-mgt
+spec: {}

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/acct-mgt-serviceaccount/clusterrolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/acct-mgt-serviceaccount/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: acct-mgt-serviceaccount
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: ServiceAccount
+    name: acct-mgt-serviceaccount
+    namespace: acct-mgt

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/acct-mgt-serviceaccount/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/acct-mgt-serviceaccount/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- clusterrolebinding.yaml

--- a/cluster-scope/bundles/acct-mgt/kustomization.yaml
+++ b/cluster-scope/bundles/acct-mgt/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base/core/namespaces/acct-mgt
+  - ../../base/rbac.authorization.k8s.io/clusterrolebindings/acct-mgt-serviceaccount

--- a/cluster-scope/overlays/ocp-staging/kustomization.yaml
+++ b/cluster-scope/overlays/ocp-staging/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ../../bundles/ocs
   - ../../bundles/metallb
   - ../../bundles/volsync
+  - ../../bundles/acct-mgt
 
   - certificates/api-certificate-letsencrypt.yaml
   - certificates/default-ingress-certificate.yaml


### PR DESCRIPTION
This deploys `cci-moc/openshift-acct-mgt` to the OCP-Staging cluster.

- [x] Create manifests
- [x] Create secret in AWS

Closes https://github.com/CCI-MOC/openshift-acct-mgt/issues/82