### PR TITLE
Remove apiGroup reference from acct-mgt cluster role binding

### DIFF
--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/acct-mgt-serviceaccount/clusterrolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/acct-mgt-serviceaccount/clusterrolebinding.yaml
@@ -8,7 +8,6 @@ roleRef:
   kind: ClusterRole
   name: cluster-admin
 subjects:
-  - apiGroup: rbac.authorization.k8s.io
-    kind: ServiceAccount
+  - kind: ServiceAccount
     name: acct-mgt-serviceaccount
     namespace: acct-mgt


### PR DESCRIPTION
Complains about `apiGroup`

```The ClusterRoleBinding "acct-mgt-serviceaccount" is invalid: subjects[0].apiGroup: Unsupported value: "rbac.authorization.k8s.io": supported values: ""```