### PR TITLE
Fix validate-manifests doesn't work on mac

### DIFF
--- a/ci/validate-manifests.sh
+++ b/ci/validate-manifests.sh
@@ -6,7 +6,7 @@
 : ${SCHEMA_LOCATION:=https://raw.githubusercontent.com/CCI-MOC/openshift-schemas/master/schemas/}
 
 find_overlays() {
-    find * -type f -regex '.*/overlays/.*/kustomization.yaml' -printf '%h\n'
+    find * -type f -regex '.*/overlays/.*/kustomization.yaml' -exec dirname {} \;
 }
 
 okay() {


### PR DESCRIPTION
The printf option for find is only present in the GNU variant of find
and doesn't work on mac.

According to the man page for find

```
%h

Leading directories of file's name (all but the last element).
If the file name contains no slashes (since it is in the current
directory) the %h specifier expands to ".".
```

This patch replaces printing the directory name with a call to dirname.

While this spawns an extra command, I find it's the most readable
alternative for what we're trying to do.