### PR TITLE
Reference coldfront from app of apps ocp-staging overlay

### DIFF
--- a/app-of-apps/envs/ocp-staging/kustomization.yaml
+++ b/app-of-apps/envs/ocp-staging/kustomization.yaml
@@ -9,5 +9,6 @@ resources:
 - netbox
 - volsync
 - acct-mgt
+- coldfront
 
 nameSuffix: -ocp-staging


### PR DESCRIPTION
Should have been there, but oops.