### PR TITLE
Fix wrong destination for coldfront

### DIFF
--- a/app-of-apps/envs/ocp-staging/coldfront/application.yaml
+++ b/app-of-apps/envs/ocp-staging/coldfront/application.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   destination:
     name: ocp-staging
-    namespace: coldfront
+    namespace: open-cluster-management-agent
   project: mocops
   source:
     path: coldfront/overlays/ocp-staging

--- a/app-of-apps/envs/ocp-staging/coldfront/application.yaml
+++ b/app-of-apps/envs/ocp-staging/coldfront/application.yaml
@@ -4,7 +4,7 @@ metadata:
   name: coldfront
 spec:
   destination:
-    name: coldfront
+    name: ocp-staging
     namespace: coldfront
   project: mocops
   source:


### PR DESCRIPTION
Should have been ocp-staging, since it refers to the cluster.