### PR TITLE
Fix coldfront-qcluster deployment container name

### DIFF
--- a/coldfront/overlays/ocp-staging/patches/deployments/coldfront-deployment.yaml
+++ b/coldfront/overlays/ocp-staging/patches/deployments/coldfront-deployment.yaml
@@ -7,10 +7,6 @@ spec:
     spec:
       containers:
         - name: coldfront
-          image: ghcr.io/nerc-project/coldfront-nerc:main
-          imagePullPolicy: Always
-          ports:
-            - containerPort: 8080
           envFrom:
             - configMapRef:
                 name: coldfront-configmap

--- a/coldfront/overlays/ocp-staging/patches/deployments/coldfront-qcluster-deployment.yaml
+++ b/coldfront/overlays/ocp-staging/patches/deployments/coldfront-qcluster-deployment.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     spec:
       containers:
-        - name: coldfront
+        - name: coldfront-qcluster
           envFrom:
             - configMapRef:
                 name: coldfront-configmap


### PR DESCRIPTION
The base specified the `coldfront-qcluster` name.
https://github.com/nerc-project/coldfront-nerc/blob/02566e8cdf2e9cd63fe67a524720f8a5cfc4d41a/k8s/overlays/prod/patches/qcluster-deployment.yaml#L9

Also removes image from the other deployment overlay.