### PR TITLE
Use username as identity for moc-testing users

### DIFF
--- a/cluster-scope/overlays/ocp-staging/oauths/cluster_patch.yaml
+++ b/cluster-scope/overlays/ocp-staging/oauths/cluster_patch.yaml
@@ -24,6 +24,8 @@ spec:
       name: moc-testing
       openID:
         claims:
+          id:
+          - preferred_username
           email:
           - email
           name:


### PR DESCRIPTION
Currently the id that's being used is the internal keycloak id, switch
to using preferred_username for moc-testing only.

I checked and there are no users on ocp-staging from moc-testing that
this might break.